### PR TITLE
Support docker as alternative to podman in Taskfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,8 @@ jobs:
   images:
     name: Build Images
     runs-on: ubuntu-latest
+    env:
+      CONTAINER_ENGINE: podman
     permissions:
       contents: read
       packages: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Module: `github.com/stacklok/brood-box`
 
 ## Commands — ALWAYS use `task` (Taskfile.yaml)
 
-**IMPORTANT**: ALWAYS use `task <target>` for building, testing, linting, formatting, and running. NEVER invoke `go build`, `go test`, `golangci-lint`, `go fmt`, `goimports`, or `podman build` directly — the Taskfile wraps these with the correct flags, ldflags, env vars, and dependency ordering. Running raw commands will produce incorrect builds or miss steps.
+**IMPORTANT**: ALWAYS use `task <target>` for building, testing, linting, formatting, and running. NEVER invoke `go build`, `go test`, `golangci-lint`, `go fmt`, `goimports`, `docker build`, or `podman build` directly — the Taskfile wraps these with the correct flags, ldflags, env vars, and dependency ordering. Running raw commands will produce incorrect builds or miss steps.
 
 ```bash
 task build                  # Build self-contained bbox with embedded propolis runtime

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ task lint
 # Format + lint + test
 task verify
 
-# Build guest VM images (requires podman)
+# Build guest VM images (requires docker or podman)
 task image-all
 ```
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -27,6 +27,8 @@ vars:
     sh: uname -s | tr '[:upper:]' '[:lower:]'
   HOST_OS_ALT:
     sh: uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/'
+  CONTAINER_ENGINE:
+    sh: echo ${CONTAINER_ENGINE:-$(command -v docker >/dev/null 2>&1 && echo docker || echo podman)}
   LDFLAGS: >-
     -X github.com/stacklok/brood-box/internal/version.Version={{.VERSION}}
     -X github.com/stacklok/brood-box/internal/version.Commit={{.COMMIT}}
@@ -228,25 +230,25 @@ tasks:
     desc: Build base guest image
     run: once
     cmds:
-      - podman build -t {{.IMAGE_REGISTRY}}/base:latest images/base/
+      - "{{.CONTAINER_ENGINE}} build -t {{.IMAGE_REGISTRY}}/base:latest images/base/"
 
   image-claude-code:
     desc: Build claude-code guest image
     deps: [image-base]
     cmds:
-      - podman build -t {{.IMAGE_REGISTRY}}/claude-code:latest images/claude-code/
+      - "{{.CONTAINER_ENGINE}} build -t {{.IMAGE_REGISTRY}}/claude-code:latest images/claude-code/"
 
   image-codex:
     desc: Build codex guest image
     deps: [image-base]
     cmds:
-      - podman build -t {{.IMAGE_REGISTRY}}/codex:latest images/codex/
+      - "{{.CONTAINER_ENGINE}} build -t {{.IMAGE_REGISTRY}}/codex:latest images/codex/"
 
   image-opencode:
     desc: Build opencode guest image
     deps: [image-base]
     cmds:
-      - podman build -t {{.IMAGE_REGISTRY}}/opencode:latest images/opencode/
+      - "{{.CONTAINER_ENGINE}} build -t {{.IMAGE_REGISTRY}}/opencode:latest images/opencode/"
 
   image-all:
     desc: Build all guest images
@@ -256,7 +258,7 @@ tasks:
     desc: Push all images to GHCR
     deps: [image-all]
     cmds:
-      - podman push {{.IMAGE_REGISTRY}}/base:latest
-      - podman push {{.IMAGE_REGISTRY}}/claude-code:latest
-      - podman push {{.IMAGE_REGISTRY}}/codex:latest
-      - podman push {{.IMAGE_REGISTRY}}/opencode:latest
+      - "{{.CONTAINER_ENGINE}} push {{.IMAGE_REGISTRY}}/base:latest"
+      - "{{.CONTAINER_ENGINE}} push {{.IMAGE_REGISTRY}}/claude-code:latest"
+      - "{{.CONTAINER_ENGINE}} push {{.IMAGE_REGISTRY}}/codex:latest"
+      - "{{.CONTAINER_ENGINE}} push {{.IMAGE_REGISTRY}}/opencode:latest"


### PR DESCRIPTION
Add CONTAINER_ENGINE variable that auto-detects docker or falls
back to podman, replacing hardcoded podman references in image tasks.
The variable can be overridden via environment variable, e.g.
CONTAINER_ENGINE=podman task image-all.

Pin CONTAINER_ENGINE=podman in CI to match the existing podman login
step. Update README and CLAUDE.md to reflect docker support.
