### PR TITLE
Use BASE_IMAGE variable to avoid registry metadata resolution in CI

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,10 +5,6 @@ variable "REGISTRY" {
   default = "ghcr.io/stacklok/brood-box"
 }
 
-variable "BASE_IMAGE" {
-  default = "${REGISTRY}/base:latest"
-}
-
 group "default" {
   targets = ["base", "claude-code", "codex", "opencode"]
 }
@@ -28,10 +24,10 @@ target "claude-code" {
   cache-from = ["type=gha,scope=claude-code"]
   cache-to   = ["type=gha,mode=max,scope=claude-code"]
   args = {
-    BASE_IMAGE = BASE_IMAGE
+    BASE_IMAGE = "brood-box-base"
   }
   contexts = {
-    "${BASE_IMAGE}" = "target:base"
+    "brood-box-base" = "target:base"
   }
 }
 
@@ -42,10 +38,10 @@ target "codex" {
   cache-from = ["type=gha,scope=codex"]
   cache-to   = ["type=gha,mode=max,scope=codex"]
   args = {
-    BASE_IMAGE = BASE_IMAGE
+    BASE_IMAGE = "brood-box-base"
   }
   contexts = {
-    "${BASE_IMAGE}" = "target:base"
+    "brood-box-base" = "target:base"
   }
 }
 
@@ -56,9 +52,9 @@ target "opencode" {
   cache-from = ["type=gha,scope=opencode"]
   cache-to   = ["type=gha,mode=max,scope=opencode"]
   args = {
-    BASE_IMAGE = BASE_IMAGE
+    BASE_IMAGE = "brood-box-base"
   }
   contexts = {
-    "${BASE_IMAGE}" = "target:base"
+    "brood-box-base" = "target:base"
   }
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,6 +5,10 @@ variable "REGISTRY" {
   default = "ghcr.io/stacklok/brood-box"
 }
 
+variable "BASE_IMAGE" {
+  default = "${REGISTRY}/base:latest"
+}
+
 group "default" {
   targets = ["base", "claude-code", "codex", "opencode"]
 }
@@ -23,8 +27,11 @@ target "claude-code" {
   tags       = ["${REGISTRY}/claude-code:latest"]
   cache-from = ["type=gha,scope=claude-code"]
   cache-to   = ["type=gha,mode=max,scope=claude-code"]
+  args = {
+    BASE_IMAGE = BASE_IMAGE
+  }
   contexts = {
-    "ghcr.io/stacklok/brood-box/base:latest" = "target:base"
+    "${BASE_IMAGE}" = "target:base"
   }
 }
 
@@ -34,8 +41,11 @@ target "codex" {
   tags       = ["${REGISTRY}/codex:latest"]
   cache-from = ["type=gha,scope=codex"]
   cache-to   = ["type=gha,mode=max,scope=codex"]
+  args = {
+    BASE_IMAGE = BASE_IMAGE
+  }
   contexts = {
-    "ghcr.io/stacklok/brood-box/base:latest" = "target:base"
+    "${BASE_IMAGE}" = "target:base"
   }
 }
 
@@ -45,7 +55,10 @@ target "opencode" {
   tags       = ["${REGISTRY}/opencode:latest"]
   cache-from = ["type=gha,scope=opencode"]
   cache-to   = ["type=gha,mode=max,scope=opencode"]
+  args = {
+    BASE_IMAGE = BASE_IMAGE
+  }
   contexts = {
-    "ghcr.io/stacklok/brood-box/base:latest" = "target:base"
+    "${BASE_IMAGE}" = "target:base"
   }
 }

--- a/images/claude-code/Dockerfile
+++ b/images/claude-code/Dockerfile
@@ -3,7 +3,8 @@
 
 # Claude Code guest image for Brood Box.
 # Installs the Claude Code native binary (Bun-based) on top of the base image.
-FROM ghcr.io/stacklok/brood-box/base:latest
+ARG BASE_IMAGE=ghcr.io/stacklok/brood-box/base:latest
+FROM ${BASE_IMAGE}
 
 # Install Claude Code native binary.
 # The installer creates a symlink at /root/.local/bin/claude pointing to the

--- a/images/codex/Dockerfile
+++ b/images/codex/Dockerfile
@@ -3,7 +3,8 @@
 
 # Codex guest image for Brood Box.
 # Installs the Codex static binary (musl-linked) on top of the base image.
-FROM ghcr.io/stacklok/brood-box/base:latest
+ARG BASE_IMAGE=ghcr.io/stacklok/brood-box/base:latest
+FROM ${BASE_IMAGE}
 
 # Install Codex static binary from GitHub Releases
 ARG TARGETARCH

--- a/images/opencode/Dockerfile
+++ b/images/opencode/Dockerfile
@@ -3,7 +3,8 @@
 
 # OpenCode guest image for Brood Box.
 # Installs the OpenCode binary (anomalyco/opencode, Bun-based, musl variant).
-FROM ghcr.io/stacklok/brood-box/base:latest
+ARG BASE_IMAGE=ghcr.io/stacklok/brood-box/base:latest
+FROM ${BASE_IMAGE}
 
 # Install OpenCode binary from GitHub Releases (glibc variant, matches Wolfi)
 ARG TARGETARCH


### PR DESCRIPTION
## Summary

- Fix CI "Build Images" workflow failing with `401 Unauthorized` when building agent images (claude-code, codex, opencode)
- The root cause: `docker buildx bake` resolves `FROM` image metadata from the registry even when a `contexts` override points to a locally-built target. Since the GHCR images are private/require auth, the metadata resolution fails with 401 before the `contexts` redirect can take effect
- Replace the hardcoded `FROM ghcr.io/stacklok/brood-box/base:latest` in each Dockerfile with `ARG BASE_IMAGE` + `FROM ${BASE_IMAGE}`, and pass the `BASE_IMAGE` variable from `docker-bake.hcl` so that bake resolves the base from the locally-built `target:base` without ever hitting the registry

## Changes

- **docker-bake.hcl**: Add `BASE_IMAGE` variable (defaults to `${REGISTRY}/base:latest`), pass it as a build arg to each agent target, and use it in the `contexts` key
- **images/claude-code/Dockerfile**: Replace hardcoded `FROM` with `ARG BASE_IMAGE` + `FROM ${BASE_IMAGE}`
- **images/codex/Dockerfile**: Same change
- **images/opencode/Dockerfile**: Same change

## Test plan

- [ ] Verify the "Build Images" CI workflow passes without 401 errors
- [ ] Verify local `task image-all` still builds successfully
- [ ] Verify standalone `docker build` of individual Dockerfiles still works (the `ARG` default preserves the original registry reference as fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)