### PR TITLE
Add opt-in host credential seeding for agent VMs

### DIFF
--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -547,7 +547,17 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 	var credentialStore credential.Store
 	if saveCredentials {
 		credStateDir := filepath.Join(xdg.ConfigHome, "broodbox", "agent-state")
-		credentialStore = infracredential.NewFSStore(credStateDir, logger)
+		fsStore := infracredential.NewFSStore(credStateDir, logger)
+		credentialStore = fsStore
+
+		// Seed Claude Code credentials from the host if not already stored.
+		// This bootstraps the first session so OAuth works without a browser.
+		if agentName == "claude-code" {
+			seeder := infracredential.NewClaudeCodeSeeder(logger)
+			if err := seeder.Seed(fsStore); err != nil {
+				logger.Warn("failed to seed Claude Code credentials", "error", err)
+			}
+		}
 	}
 
 	if credentialStore != nil {

--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -1034,9 +1034,9 @@ func sanitizeAll(ss []string) []string {
 	return out
 }
 
-// credentialSeederForAgent returns a CredentialSeeder for the given agent,
+// credentialSeederForAgent returns a Seeder for the given agent,
 // or nil if no seeder is available.
-func credentialSeederForAgent(name string, logger *slog.Logger) credential.CredentialSeeder {
+func credentialSeederForAgent(name string, logger *slog.Logger) credential.Seeder {
 	switch name {
 	case "claude-code":
 		return infracredential.NewClaudeCodeSeeder(logger)

--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -84,6 +84,7 @@ func rootCmd() *cobra.Command {
 		noGitToken        bool
 		noGitSSHAgent     bool
 		noSaveCredentials bool
+		seedCredentials   bool
 		noFirmwareDL      bool
 		noImageCache      bool
 		timings           bool
@@ -143,6 +144,7 @@ Example:
 				noGitToken:        noGitToken,
 				noGitSSHAgent:     noGitSSHAgent,
 				noSaveCredentials: noSaveCredentials,
+				seedCredentials:   seedCredentials,
 				noFirmwareDL:      noFirmwareDL,
 				noImageCache:      noImageCache,
 				timings:           timings,
@@ -174,6 +176,7 @@ Example:
 	cmd.Flags().BoolVar(&noGitToken, "no-git-token", false, "Disable forwarding GITHUB_TOKEN/GH_TOKEN into the VM")
 	cmd.Flags().BoolVar(&noGitSSHAgent, "no-git-ssh-agent", false, "Disable SSH agent forwarding into the VM")
 	cmd.Flags().BoolVar(&noSaveCredentials, "no-save-credentials", false, "Disable saving agent credentials between sessions (enabled by default)")
+	cmd.Flags().BoolVar(&seedCredentials, "seed-credentials", false, "Seed agent credentials from host (e.g. macOS Keychain) into the VM")
 	cmd.Flags().BoolVar(&noFirmwareDL, "no-firmware-download", false, "Disable firmware download (use system libkrunfw only)")
 	cmd.Flags().BoolVar(&noImageCache, "no-image-cache", false, "Disable OCI image caching (fresh pull every run)")
 	cmd.Flags().BoolVar(&timings, "timings", false, "Print per-phase timing summary after run")
@@ -286,6 +289,7 @@ type runFlags struct {
 	noGitToken        bool
 	noGitSSHAgent     bool
 	noSaveCredentials bool
+	seedCredentials   bool
 	noFirmwareDL      bool
 	noImageCache      bool
 	timings           bool
@@ -544,18 +548,22 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 	// Resolve credential persistence setting.
 	saveCredentials := cfg.Auth.SaveCredentialsEnabled() && !flags.noSaveCredentials
 
+	// Resolve host credential seeding: opt-in via flag or config.
+	seedCreds := flags.seedCredentials || cfg.Auth.SeedHostCredentialsEnabled()
+
 	var credentialStore credential.Store
 	if saveCredentials {
 		credStateDir := filepath.Join(xdg.ConfigHome, "broodbox", "agent-state")
 		fsStore := infracredential.NewFSStore(credStateDir, logger)
 		credentialStore = fsStore
 
-		// Seed Claude Code credentials from the host if not already stored.
-		// This bootstraps the first session so OAuth works without a browser.
-		if agentName == "claude-code" {
-			seeder := infracredential.NewClaudeCodeSeeder(logger)
-			if err := seeder.Seed(fsStore); err != nil {
-				logger.Warn("failed to seed Claude Code credentials", "error", err)
+		if seedCreds && saveCredentials {
+			// Seeder selection will be wired in the next task.
+			if agentName == "claude-code" {
+				seeder := infracredential.NewClaudeCodeSeeder(logger)
+				if err := seeder.Seed(fsStore); err != nil {
+					logger.Warn("failed to seed credentials", "agent", agentName, "error", err)
+				}
 			}
 		}
 	}
@@ -855,6 +863,11 @@ func warnLocalConfigOverrides(w io.Writer, localCfg, globalCfg *domainconfig.Con
 	// Auth.SaveCredentials — always ignored for security, warn if set.
 	if localCfg.Auth.SaveCredentials != nil {
 		warnings = append(warnings, "auth.save_credentials is ignored in workspace config — use --no-save-credentials flag or global config")
+	}
+
+	// Auth.SeedHostCredentials — always ignored for security, warn if set.
+	if localCfg.Auth.SeedHostCredentials != nil {
+		warnings = append(warnings, "auth.seed_host_credentials is ignored in workspace config — use --seed-credentials flag or global config")
 	}
 
 	// Review.ExcludePatterns — can hide changes from diff review.

--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -557,12 +557,10 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		fsStore := infracredential.NewFSStore(credStateDir, logger)
 		credentialStore = fsStore
 
-		if seedCreds && saveCredentials {
-			// Seeder selection will be wired in the next task.
-			if agentName == "claude-code" {
-				seeder := infracredential.NewClaudeCodeSeeder(logger)
+		if seedCreds {
+			if seeder := credentialSeederForAgent(agentName, logger); seeder != nil {
 				if err := seeder.Seed(fsStore); err != nil {
-					logger.Warn("failed to seed credentials", "agent", agentName, "error", err)
+					logger.Warn("credential seeding failed", "agent", agentName, "error", err)
 				}
 			}
 		}
@@ -1034,6 +1032,17 @@ func sanitizeAll(ss []string) []string {
 		out[i] = sanitizeValue(s)
 	}
 	return out
+}
+
+// credentialSeederForAgent returns a CredentialSeeder for the given agent,
+// or nil if no seeder is available.
+func credentialSeederForAgent(name string, logger *slog.Logger) credential.CredentialSeeder {
+	switch name {
+	case "claude-code":
+		return infracredential.NewClaudeCodeSeeder(logger)
+	default:
+		return nil
+	}
 }
 
 // runtimeCacheDir returns the directory used for extracting embedded runtime

--- a/cmd/bbox/main_test.go
+++ b/cmd/bbox/main_test.go
@@ -104,6 +104,17 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 				"adds review exclude patterns: **/*.go, secrets/",
 			),
 		},
+		// --- Auth seed_host_credentials ---
+		{
+			name: "auth.seed_host_credentials ignored warning",
+			local: &domainconfig.Config{
+				Auth: domainconfig.AuthConfig{SeedHostCredentials: boolPtr(true)},
+			},
+			global: defaultGlobal,
+			expected: wrapWarnings(
+				"auth.seed_host_credentials is ignored in workspace config — use --seed-credentials flag or global config",
+			),
+		},
 		// --- Defaults ---
 		{
 			name: "defaults egress profile tightens",
@@ -346,6 +357,10 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 					Enabled:         boolPtr(true),
 					ExcludePatterns: []string{"*.log"},
 				},
+				Auth: domainconfig.AuthConfig{
+					SaveCredentials:     boolPtr(true),
+					SeedHostCredentials: boolPtr(true),
+				},
 				Defaults: domainconfig.DefaultsConfig{
 					EgressProfile: "locked",
 					CPUs:          8,
@@ -377,6 +392,8 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 			global: defaultGlobal,
 			expected: wrapWarnings(
 				"review.enabled (interactive review) is ignored for security — use --review or global config",
+				"auth.save_credentials is ignored in workspace config — use --no-save-credentials flag or global config",
+				"auth.seed_host_credentials is ignored in workspace config — use --seed-credentials flag or global config",
 				"adds review exclude patterns: *.log",
 				"sets default egress profile: locked",
 				"sets default CPUs: 8",

--- a/internal/infra/credential/claudeseeder.go
+++ b/internal/infra/credential/claudeseeder.go
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package credential
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	domaincredential "github.com/stacklok/brood-box/pkg/domain/credential"
+)
+
+// claudeCodeCredPath is the relative path to the Claude Code credentials file
+// within the sandbox user's home directory.
+const claudeCodeCredPath = ".claude/.credentials.json"
+
+// keychainService is the macOS Keychain service name used by Claude Code.
+const keychainService = "Claude Code-credentials"
+
+// ClaudeCodeSeeder seeds Claude Code OAuth credentials from the host into the
+// credential store. It reads from the macOS Keychain (preferred) or the host's
+// ~/.claude/.credentials.json and writes to the store when:
+//   - No credentials exist yet (first run), or
+//   - The stored access token has expired and the host has a fresher one.
+type ClaudeCodeSeeder struct {
+	logger *slog.Logger
+}
+
+// NewClaudeCodeSeeder creates a new ClaudeCodeSeeder.
+func NewClaudeCodeSeeder(logger *slog.Logger) *ClaudeCodeSeeder {
+	return &ClaudeCodeSeeder{logger: logger}
+}
+
+// readHostCreds is a package-level indirection for readHostClaudeCredentials,
+// allowing tests to inject fake host credential data without hitting the real
+// Keychain or filesystem.
+var readHostCreds = readHostClaudeCredentials
+
+// Seed implements credential.CredentialSeeder. It ensures the store has a fresh
+// OAuth token for Claude Code by comparing host and stored expiry timestamps.
+// Returns nil when no host credentials are available (not an error).
+func (s *ClaudeCodeSeeder) Seed(store domaincredential.Store) error {
+	const agentName = "claude-code"
+
+	// Read host credentials first — if unavailable, nothing to do.
+	hostCreds, source, err := readHostCreds()
+	if err != nil {
+		s.logger.Debug("no host Claude Code credentials found", "error", err)
+		return nil
+	}
+
+	storedData, readErr := store.ReadFile(agentName, claudeCodeCredPath)
+
+	// If stored credentials exist and are not expired, keep them.
+	if readErr == nil {
+		storedExp := extractExpiresAt(storedData)
+		hostExp := extractExpiresAt(hostCreds)
+		if storedExp > 0 && storedExp > timeNowMs() {
+			s.logger.Debug("stored credentials still valid, skipping seed",
+				"expires_at", storedExp)
+			return nil
+		}
+		// Stored token expired — check if host has a fresher one.
+		if hostExp <= storedExp {
+			s.logger.Debug("host credentials not fresher than stored, skipping seed",
+				"stored_expires", storedExp, "host_expires", hostExp)
+			return nil
+		}
+		s.logger.Info("stored credentials expired, refreshing from host",
+			"source", source)
+	}
+
+	// Write host credentials to the store. Use OverwriteFile when replacing
+	// existing credentials, SeedFile for the initial write.
+	if readErr == nil {
+		if err := store.OverwriteFile(agentName, claudeCodeCredPath, hostCreds); err != nil {
+			return fmt.Errorf("overwriting Claude Code credentials: %w", err)
+		}
+	} else {
+		if err := store.SeedFile(agentName, claudeCodeCredPath, hostCreds); err != nil {
+			return fmt.Errorf("seeding Claude Code credentials: %w", err)
+		}
+	}
+
+	s.logger.Info("seeded Claude Code credentials from host", "source", source)
+	return nil
+}
+
+// timeNowMs returns the current time in milliseconds since epoch.
+// Declared as a variable for testing.
+var timeNowMs = func() int64 {
+	return time.Now().UnixMilli()
+}
+
+// extractExpiresAt parses the expiresAt field from Claude Code credentials JSON.
+// Returns 0 if parsing fails.
+func extractExpiresAt(data []byte) int64 {
+	var wrapper struct {
+		ClaudeAiOauth struct {
+			ExpiresAt int64 `json:"expiresAt"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return 0
+	}
+	return wrapper.ClaudeAiOauth.ExpiresAt
+}
+
+// readHostClaudeCredentials attempts to read Claude Code credentials from the
+// host system. Returns the raw JSON content, the source description, and any error.
+// On macOS, tries the Keychain first, then falls back to the credentials file.
+// On other platforms, only checks the credentials file.
+func readHostClaudeCredentials() ([]byte, string, error) {
+	if runtime.GOOS == "darwin" {
+		if creds, err := readKeychainCredentials(); err == nil {
+			return creds, "macOS Keychain", nil
+		}
+	}
+
+	// Fall back to credentials file.
+	creds, err := readCredentialsFile()
+	if err != nil {
+		return nil, "", fmt.Errorf("no host credentials found: %w", err)
+	}
+	return creds, "~/.claude/.credentials.json", nil
+}
+
+// readKeychainCredentials reads Claude Code credentials from the macOS Keychain.
+func readKeychainCredentials() ([]byte, error) {
+	//nolint:gosec // Arguments are constant strings, not user input.
+	out, err := exec.Command("security", "find-generic-password", "-s", keychainService, "-w").Output()
+	if err != nil {
+		return nil, fmt.Errorf("keychain lookup failed: %w", err)
+	}
+
+	// The macOS security command appends a trailing newline — trim it.
+	out = bytes.TrimSpace(out)
+
+	if len(out) > int(domaincredential.MaxFileSize) {
+		return nil, fmt.Errorf("keychain credential exceeds max size (%d bytes)", domaincredential.MaxFileSize)
+	}
+
+	// Validate it's valid JSON before using it.
+	if !json.Valid(out) {
+		return nil, fmt.Errorf("keychain entry is not valid JSON")
+	}
+
+	return out, nil
+}
+
+// readCredentialsFile reads Claude Code credentials from ~/.claude/.credentials.json.
+func readCredentialsFile() ([]byte, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving home dir: %w", err)
+	}
+
+	path := filepath.Join(home, ".claude", ".credentials.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading credentials file: %w", err)
+	}
+
+	if len(data) > int(domaincredential.MaxFileSize) {
+		return nil, fmt.Errorf("credentials file exceeds max size (%d bytes)", domaincredential.MaxFileSize)
+	}
+
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("credentials file is not valid JSON")
+	}
+
+	return data, nil
+}

--- a/internal/infra/credential/claudeseeder.go
+++ b/internal/infra/credential/claudeseeder.go
@@ -6,6 +6,7 @@ package credential
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -30,27 +31,28 @@ const keychainService = "Claude Code-credentials"
 //   - No credentials exist yet (first run), or
 //   - The stored access token has expired and the host has a fresher one.
 type ClaudeCodeSeeder struct {
-	logger *slog.Logger
+	logger    *slog.Logger
+	readHost  func() ([]byte, string, error) // reads host credentials
+	nowMs     func() int64                   // current time in epoch ms
 }
 
-// NewClaudeCodeSeeder creates a new ClaudeCodeSeeder.
+// NewClaudeCodeSeeder creates a new ClaudeCodeSeeder with production defaults.
 func NewClaudeCodeSeeder(logger *slog.Logger) *ClaudeCodeSeeder {
-	return &ClaudeCodeSeeder{logger: logger}
+	return &ClaudeCodeSeeder{
+		logger:   logger,
+		readHost: readHostClaudeCredentials,
+		nowMs:    func() int64 { return time.Now().UnixMilli() },
+	}
 }
 
-// readHostCreds is a package-level indirection for readHostClaudeCredentials,
-// allowing tests to inject fake host credential data without hitting the real
-// Keychain or filesystem.
-var readHostCreds = readHostClaudeCredentials
-
-// Seed implements credential.CredentialSeeder. It ensures the store has a fresh
-// OAuth token for Claude Code by comparing host and stored expiry timestamps.
-// Returns nil when no host credentials are available (not an error).
-func (s *ClaudeCodeSeeder) Seed(store domaincredential.Store) error {
+// Seed implements credential.Seeder. It ensures the file store has a
+// fresh OAuth token for Claude Code by comparing host and stored expiry
+// timestamps. Returns nil when no host credentials are available (not an error).
+func (s *ClaudeCodeSeeder) Seed(store domaincredential.FileStore) error {
 	const agentName = "claude-code"
 
 	// Read host credentials first — if unavailable, nothing to do.
-	hostCreds, source, err := readHostCreds()
+	hostCreds, source, err := s.readHost()
 	if err != nil {
 		s.logger.Debug("no host Claude Code credentials found", "error", err)
 		return nil
@@ -58,11 +60,16 @@ func (s *ClaudeCodeSeeder) Seed(store domaincredential.Store) error {
 
 	storedData, readErr := store.ReadFile(agentName, claudeCodeCredPath)
 
-	// If stored credentials exist and are not expired, keep them.
+	// Distinguish "not found" (first run) from real errors (permissions, etc).
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return fmt.Errorf("reading stored credentials: %w", readErr)
+	}
+
+	// Stored credentials exist — check expiry before overwriting.
 	if readErr == nil {
 		storedExp := extractExpiresAt(storedData)
 		hostExp := extractExpiresAt(hostCreds)
-		if storedExp > 0 && storedExp > timeNowMs() {
+		if storedExp > 0 && storedExp > s.nowMs() {
 			s.logger.Debug("stored credentials still valid, skipping seed",
 				"expires_at", storedExp)
 			return nil
@@ -75,28 +82,19 @@ func (s *ClaudeCodeSeeder) Seed(store domaincredential.Store) error {
 		}
 		s.logger.Info("stored credentials expired, refreshing from host",
 			"source", source)
-	}
-
-	// Write host credentials to the store. Use OverwriteFile when replacing
-	// existing credentials, SeedFile for the initial write.
-	if readErr == nil {
 		if err := store.OverwriteFile(agentName, claudeCodeCredPath, hostCreds); err != nil {
 			return fmt.Errorf("overwriting Claude Code credentials: %w", err)
 		}
-	} else {
-		if err := store.SeedFile(agentName, claudeCodeCredPath, hostCreds); err != nil {
-			return fmt.Errorf("seeding Claude Code credentials: %w", err)
-		}
+		s.logger.Info("seeded Claude Code credentials from host", "source", source)
+		return nil
 	}
 
+	// No stored credentials — initial seed.
+	if err := store.SeedFile(agentName, claudeCodeCredPath, hostCreds); err != nil {
+		return fmt.Errorf("seeding Claude Code credentials: %w", err)
+	}
 	s.logger.Info("seeded Claude Code credentials from host", "source", source)
 	return nil
-}
-
-// timeNowMs returns the current time in milliseconds since epoch.
-// Declared as a variable for testing.
-var timeNowMs = func() int64 {
-	return time.Now().UnixMilli()
 }
 
 // extractExpiresAt parses the expiresAt field from Claude Code credentials JSON.
@@ -119,9 +117,11 @@ func extractExpiresAt(data []byte) int64 {
 // On other platforms, only checks the credentials file.
 func readHostClaudeCredentials() ([]byte, string, error) {
 	if runtime.GOOS == "darwin" {
-		if creds, err := readKeychainCredentials(); err == nil {
+		creds, err := readKeychainCredentials()
+		if err == nil {
 			return creds, "macOS Keychain", nil
 		}
+		slog.Debug("keychain read failed, falling back to credentials file", "error", err)
 	}
 
 	// Fall back to credentials file.

--- a/internal/infra/credential/claudeseeder_test.go
+++ b/internal/infra/credential/claudeseeder_test.go
@@ -73,30 +73,35 @@ func makeCreds(t *testing.T, expiresAt int64) []byte {
 	return data
 }
 
-// TestSeedExpiry tests the expiry-aware credential seeding logic by calling
-// ClaudeCodeSeeder.Seed with injected host credentials via the readHostCreds
-// package-level variable.
-// NOT parallel — subtests mutate the package-level timeNowMs and readHostCreds variables.
+// testSeeder creates a ClaudeCodeSeeder with injected host credential reader
+// and time function for testing.
+func testSeeder(t *testing.T, readHost func() ([]byte, string, error), nowMs func() int64) *ClaudeCodeSeeder {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	s := NewClaudeCodeSeeder(logger)
+	if readHost != nil {
+		s.readHost = readHost
+	}
+	if nowMs != nil {
+		s.nowMs = nowMs
+	}
+	return s
+}
+
+// TestSeedExpiry tests the expiry-aware credential seeding logic.
 func TestSeedExpiry(t *testing.T) {
+	t.Parallel()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
-	origTimeNowMs := timeNowMs
-	origReadHostCreds := readHostCreds
-	t.Cleanup(func() {
-		timeNowMs = origTimeNowMs
-		readHostCreds = origReadHostCreds
-	})
-
-	seeder := NewClaudeCodeSeeder(logger)
-
 	t.Run("seeds when no stored credentials exist", func(t *testing.T) {
+		t.Parallel()
 		baseDir := t.TempDir()
 		store := NewFSStore(baseDir, logger)
 		hostCreds := makeCreds(t, 9999999999999)
 
-		readHostCreds = func() ([]byte, string, error) {
+		seeder := testSeeder(t, func() ([]byte, string, error) {
 			return hostCreds, "test", nil
-		}
+		}, nil)
 
 		if err := seeder.Seed(store); err != nil {
 			t.Fatalf("Seed failed: %v", err)
@@ -112,6 +117,7 @@ func TestSeedExpiry(t *testing.T) {
 	})
 
 	t.Run("keeps valid stored credentials", func(t *testing.T) {
+		t.Parallel()
 		baseDir := t.TempDir()
 		store := NewFSStore(baseDir, logger)
 
@@ -121,10 +127,9 @@ func TestSeedExpiry(t *testing.T) {
 		}
 
 		// Host has different credentials, but stored ones are still valid.
-		readHostCreds = func() ([]byte, string, error) {
+		seeder := testSeeder(t, func() ([]byte, string, error) {
 			return makeCreds(t, 8888888888888), "test", nil
-		}
-		timeNowMs = func() int64 { return 1000000000000 }
+		}, func() int64 { return 1000000000000 })
 
 		if err := seeder.Seed(store); err != nil {
 			t.Fatalf("Seed failed: %v", err)
@@ -140,6 +145,7 @@ func TestSeedExpiry(t *testing.T) {
 	})
 
 	t.Run("overwrites expired with fresher host creds", func(t *testing.T) {
+		t.Parallel()
 		baseDir := t.TempDir()
 		store := NewFSStore(baseDir, logger)
 
@@ -148,10 +154,9 @@ func TestSeedExpiry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		timeNowMs = func() int64 { return 2000000000000 }
-		readHostCreds = func() ([]byte, string, error) {
+		seeder := testSeeder(t, func() ([]byte, string, error) {
 			return makeCreds(t, 3000000000000), "test", nil
-		}
+		}, func() int64 { return 2000000000000 })
 
 		if err := seeder.Seed(store); err != nil {
 			t.Fatalf("Seed failed: %v", err)
@@ -167,6 +172,7 @@ func TestSeedExpiry(t *testing.T) {
 	})
 
 	t.Run("skips when host creds not fresher", func(t *testing.T) {
+		t.Parallel()
 		baseDir := t.TempDir()
 		store := NewFSStore(baseDir, logger)
 
@@ -175,11 +181,10 @@ func TestSeedExpiry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		timeNowMs = func() int64 { return 2000000000000 }
 		// Host creds are older than stored.
-		readHostCreds = func() ([]byte, string, error) {
+		seeder := testSeeder(t, func() ([]byte, string, error) {
 			return makeCreds(t, 500000000000), "test", nil
-		}
+		}, func() int64 { return 2000000000000 })
 
 		if err := seeder.Seed(store); err != nil {
 			t.Fatalf("Seed failed: %v", err)
@@ -195,12 +200,13 @@ func TestSeedExpiry(t *testing.T) {
 	})
 
 	t.Run("no-op when host creds unavailable", func(t *testing.T) {
+		t.Parallel()
 		baseDir := t.TempDir()
 		store := NewFSStore(baseDir, logger)
 
-		readHostCreds = func() ([]byte, string, error) {
+		seeder := testSeeder(t, func() ([]byte, string, error) {
 			return nil, "", fmt.Errorf("no credentials available")
-		}
+		}, nil)
 
 		if err := seeder.Seed(store); err != nil {
 			t.Fatalf("Seed should return nil when host creds unavailable: %v", err)

--- a/internal/infra/credential/claudeseeder_test.go
+++ b/internal/infra/credential/claudeseeder_test.go
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package credential
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestExtractExpiresAt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data string
+		want int64
+	}{
+		{
+			name: "valid credentials",
+			data: `{"claudeAiOauth":{"accessToken":"tok","expiresAt":1773402187165}}`,
+			want: 1773402187165,
+		},
+		{
+			name: "missing expiresAt",
+			data: `{"claudeAiOauth":{"accessToken":"tok"}}`,
+			want: 0,
+		},
+		{
+			name: "empty object",
+			data: `{}`,
+			want: 0,
+		},
+		{
+			name: "invalid JSON",
+			data: `not json`,
+			want: 0,
+		},
+		{
+			name: "empty input",
+			data: ``,
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractExpiresAt([]byte(tt.data))
+			if got != tt.want {
+				t.Errorf("extractExpiresAt() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// makeCreds returns a JSON credential blob with the given expiresAt value.
+func makeCreds(t *testing.T, expiresAt int64) []byte {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{
+		"claudeAiOauth": map[string]any{
+			"accessToken":  "sk-ant-oat01-test",
+			"refreshToken": "sk-ant-ort01-test",
+			"expiresAt":    expiresAt,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// TestSeedExpiry tests the expiry-aware credential seeding logic by calling
+// ClaudeCodeSeeder.Seed with injected host credentials via the readHostCreds
+// package-level variable.
+// NOT parallel — subtests mutate the package-level timeNowMs and readHostCreds variables.
+func TestSeedExpiry(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	origTimeNowMs := timeNowMs
+	origReadHostCreds := readHostCreds
+	t.Cleanup(func() {
+		timeNowMs = origTimeNowMs
+		readHostCreds = origReadHostCreds
+	})
+
+	seeder := NewClaudeCodeSeeder(logger)
+
+	t.Run("seeds when no stored credentials exist", func(t *testing.T) {
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+		hostCreds := makeCreds(t, 9999999999999)
+
+		readHostCreds = func() ([]byte, string, error) {
+			return hostCreds, "test", nil
+		}
+
+		if err := seeder.Seed(store); err != nil {
+			t.Fatalf("Seed failed: %v", err)
+		}
+
+		data, err := store.ReadFile("claude-code", claudeCodeCredPath)
+		if err != nil {
+			t.Fatalf("expected seeded file: %v", err)
+		}
+		if extractExpiresAt(data) != 9999999999999 {
+			t.Fatalf("expected expiresAt=9999999999999, got %d", extractExpiresAt(data))
+		}
+	})
+
+	t.Run("keeps valid stored credentials", func(t *testing.T) {
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		// Pre-seed stored credentials with a far-future expiry.
+		if err := store.SeedFile("claude-code", claudeCodeCredPath, makeCreds(t, 9999999999999)); err != nil {
+			t.Fatal(err)
+		}
+
+		// Host has different credentials, but stored ones are still valid.
+		readHostCreds = func() ([]byte, string, error) {
+			return makeCreds(t, 8888888888888), "test", nil
+		}
+		timeNowMs = func() int64 { return 1000000000000 }
+
+		if err := seeder.Seed(store); err != nil {
+			t.Fatalf("Seed failed: %v", err)
+		}
+
+		data, err := store.ReadFile("claude-code", claudeCodeCredPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if extractExpiresAt(data) != 9999999999999 {
+			t.Fatal("stored credentials should not have been overwritten")
+		}
+	})
+
+	t.Run("overwrites expired with fresher host creds", func(t *testing.T) {
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		// Store credentials that are already expired.
+		if err := store.SeedFile("claude-code", claudeCodeCredPath, makeCreds(t, 1000000000000)); err != nil {
+			t.Fatal(err)
+		}
+
+		timeNowMs = func() int64 { return 2000000000000 }
+		readHostCreds = func() ([]byte, string, error) {
+			return makeCreds(t, 3000000000000), "test", nil
+		}
+
+		if err := seeder.Seed(store); err != nil {
+			t.Fatalf("Seed failed: %v", err)
+		}
+
+		data, err := store.ReadFile("claude-code", claudeCodeCredPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if extractExpiresAt(data) != 3000000000000 {
+			t.Fatalf("expected expiresAt=3000000000000, got %d", extractExpiresAt(data))
+		}
+	})
+
+	t.Run("skips when host creds not fresher", func(t *testing.T) {
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		// Store credentials that are expired.
+		if err := store.SeedFile("claude-code", claudeCodeCredPath, makeCreds(t, 1000000000000)); err != nil {
+			t.Fatal(err)
+		}
+
+		timeNowMs = func() int64 { return 2000000000000 }
+		// Host creds are older than stored.
+		readHostCreds = func() ([]byte, string, error) {
+			return makeCreds(t, 500000000000), "test", nil
+		}
+
+		if err := seeder.Seed(store); err != nil {
+			t.Fatalf("Seed failed: %v", err)
+		}
+
+		data, err := store.ReadFile("claude-code", claudeCodeCredPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if extractExpiresAt(data) != 1000000000000 {
+			t.Fatal("stored credentials should not have been changed")
+		}
+	})
+
+	t.Run("no-op when host creds unavailable", func(t *testing.T) {
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		readHostCreds = func() ([]byte, string, error) {
+			return nil, "", fmt.Errorf("no credentials available")
+		}
+
+		if err := seeder.Seed(store); err != nil {
+			t.Fatalf("Seed should return nil when host creds unavailable: %v", err)
+		}
+
+		_, err := store.ReadFile("claude-code", claudeCodeCredPath)
+		if err == nil {
+			t.Fatal("expected no stored credentials when host creds unavailable")
+		}
+	})
+}

--- a/internal/infra/credential/store.go
+++ b/internal/infra/credential/store.go
@@ -355,8 +355,21 @@ func (s *FSStore) SeedFile(agentName, relPath string, content []byte) error {
 		return fmt.Errorf("creating parent dirs: %w", err)
 	}
 
-	if err := os.WriteFile(dst, content, filePerm); err != nil {
-		return fmt.Errorf("writing seed file: %w", err)
+	// Atomic write: temp file + rename to avoid partial files on crash,
+	// matching the OverwriteFile and extractFile patterns.
+	tmpPath, err := tempFilePath(filepath.Dir(dst))
+	if err != nil {
+		return fmt.Errorf("generating temp path: %w", err)
+	}
+
+	if err := os.WriteFile(tmpPath, content, filePerm); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, dst); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("atomic rename: %w", err)
 	}
 
 	s.logger.Info("seeded credential file",
@@ -376,6 +389,10 @@ func (s *FSStore) ReadFile(agentName, relPath string) ([]byte, error) {
 	data, err := os.ReadFile(src)
 	if err != nil {
 		return nil, fmt.Errorf("reading credential file: %w", err)
+	}
+
+	if int64(len(data)) > credential.MaxFileSize {
+		return nil, fmt.Errorf("credential file exceeds max size (%d bytes)", credential.MaxFileSize)
 	}
 
 	return data, nil

--- a/internal/infra/credential/store.go
+++ b/internal/infra/credential/store.go
@@ -309,6 +309,113 @@ func (s *FSStore) extractFile(src, dst, agentDir string) error {
 	return nil
 }
 
+// resolvePath validates agentName and relPath, then returns the resolved
+// filesystem path. Returns an error for invalid names or path traversal.
+func (s *FSStore) resolvePath(agentName, relPath string) (string, error) {
+	if !isSafeName(agentName) {
+		return "", fmt.Errorf("invalid agent name: %q", agentName)
+	}
+
+	for _, part := range strings.Split(relPath, "/") {
+		if part == "" {
+			continue
+		}
+		if !isSafeName(part) {
+			return "", fmt.Errorf("invalid path component %q in %q", part, relPath)
+		}
+	}
+
+	resolved := filepath.Join(s.baseDir, agentName, relPath)
+
+	agentDir := filepath.Join(s.baseDir, agentName)
+	if _, err := containedPath(agentDir, resolved); err != nil {
+		return "", fmt.Errorf("path containment: %w", err)
+	}
+
+	return resolved, nil
+}
+
+// SeedFile writes a file into the credential store for an agent if it does
+// not already exist. relPath is relative to the agent's home directory
+// (e.g. ".claude/.credentials.json").
+func (s *FSStore) SeedFile(agentName, relPath string, content []byte) error {
+	dst, err := s.resolvePath(agentName, relPath)
+	if err != nil {
+		return err
+	}
+
+	// No-op if the file already exists.
+	if _, err := os.Stat(dst); err == nil {
+		s.logger.Debug("credential file already exists, skipping seed",
+			"agent", agentName, "path", relPath)
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
+		return fmt.Errorf("creating parent dirs: %w", err)
+	}
+
+	if err := os.WriteFile(dst, content, filePerm); err != nil {
+		return fmt.Errorf("writing seed file: %w", err)
+	}
+
+	s.logger.Info("seeded credential file",
+		"agent", agentName, "path", relPath)
+	return nil
+}
+
+// ReadFile reads a file from the credential store for an agent. relPath is
+// relative to the agent's home directory (e.g. ".claude/.credentials.json").
+// Returns os.ErrNotExist if the file does not exist.
+func (s *FSStore) ReadFile(agentName, relPath string) ([]byte, error) {
+	src, err := s.resolvePath(agentName, relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return nil, fmt.Errorf("reading credential file: %w", err)
+	}
+
+	return data, nil
+}
+
+// OverwriteFile writes a file into the credential store for an agent,
+// replacing any existing content. relPath is relative to the agent's home
+// directory (e.g. ".claude/.credentials.json").
+func (s *FSStore) OverwriteFile(agentName, relPath string, content []byte) error {
+	dst, err := s.resolvePath(agentName, relPath)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
+		return fmt.Errorf("creating parent dirs: %w", err)
+	}
+
+	// Atomic write: temp file + rename to avoid data-loss window and
+	// TOCTOU symlink risk, matching the extractFile pattern.
+	tmpPath, err := tempFilePath(filepath.Dir(dst))
+	if err != nil {
+		return fmt.Errorf("generating temp path: %w", err)
+	}
+
+	if err := os.WriteFile(tmpPath, content, filePerm); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, dst); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("atomic rename: %w", err)
+	}
+
+	s.logger.Info("overwrote credential file",
+		"agent", agentName, "path", relPath)
+	return nil
+}
+
 // isSafeName rejects path components that could cause traversal or injection.
 func isSafeName(name string) bool {
 	if name == "" || name == "." || name == ".." {

--- a/internal/infra/credential/store_test.go
+++ b/internal/infra/credential/store_test.go
@@ -4,6 +4,7 @@
 package credential
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -284,6 +285,218 @@ func TestFSStore(t *testing.T) {
 			tt.check(t, baseDir, rootfsPath)
 		})
 	}
+}
+
+func TestSeedFile(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	t.Run("seeds new file", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		err := store.SeedFile("claude-code", ".claude/.credentials.json", []byte(`{"token":"abc"}`))
+		if err != nil {
+			t.Fatalf("SeedFile failed: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(baseDir, "claude-code", ".claude", ".credentials.json"))
+		if err != nil {
+			t.Fatalf("expected seeded file: %v", err)
+		}
+		if string(data) != `{"token":"abc"}` {
+			t.Fatalf("unexpected content: %s", data)
+		}
+	})
+
+	t.Run("skips existing file", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		// Pre-create the file.
+		dst := filepath.Join(baseDir, "claude-code", ".claude", ".credentials.json")
+		if err := os.MkdirAll(filepath.Dir(dst), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dst, []byte("original"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		err := store.SeedFile("claude-code", ".claude/.credentials.json", []byte("replacement"))
+		if err != nil {
+			t.Fatalf("SeedFile failed: %v", err)
+		}
+
+		data, err := os.ReadFile(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "original" {
+			t.Fatalf("seed should not overwrite existing file, got: %s", data)
+		}
+	})
+
+	t.Run("rejects path traversal", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		err := store.SeedFile("claude-code", "../escape/creds.json", []byte("evil"))
+		if err == nil {
+			t.Fatal("expected error for path traversal")
+		}
+	})
+
+	t.Run("rejects invalid agent name", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		err := store.SeedFile("../evil", ".claude/.credentials.json", []byte("x"))
+		if err == nil {
+			t.Fatal("expected error for invalid agent name")
+		}
+	})
+}
+
+func TestReadFile(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	t.Run("reads existing file", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		// Pre-create the file.
+		dst := filepath.Join(baseDir, "claude-code", ".claude", ".credentials.json")
+		if err := os.MkdirAll(filepath.Dir(dst), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dst, []byte(`{"token":"abc"}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		data, err := store.ReadFile("claude-code", ".claude/.credentials.json")
+		if err != nil {
+			t.Fatalf("ReadFile failed: %v", err)
+		}
+		if string(data) != `{"token":"abc"}` {
+			t.Fatalf("unexpected content: %s", data)
+		}
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		_, err := store.ReadFile("claude-code", ".claude/.credentials.json")
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected os.ErrNotExist, got: %v", err)
+		}
+	})
+
+	t.Run("rejects invalid agent name", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		_, err := store.ReadFile("../evil", ".claude/.credentials.json")
+		if err == nil {
+			t.Fatal("expected error for invalid agent name")
+		}
+	})
+
+	t.Run("rejects path traversal", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		_, err := store.ReadFile("claude-code", "../escape/creds.json")
+		if err == nil {
+			t.Fatal("expected error for path traversal")
+		}
+	})
+}
+
+func TestOverwriteFile(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	t.Run("writes new file", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		err := store.OverwriteFile("claude-code", ".claude/.credentials.json", []byte(`{"token":"abc"}`))
+		if err != nil {
+			t.Fatalf("OverwriteFile failed: %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(baseDir, "claude-code", ".claude", ".credentials.json"))
+		if err != nil {
+			t.Fatalf("expected written file: %v", err)
+		}
+		if string(data) != `{"token":"abc"}` {
+			t.Fatalf("unexpected content: %s", data)
+		}
+	})
+
+	t.Run("overwrites existing file", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		// Pre-create the file with original content.
+		dst := filepath.Join(baseDir, "claude-code", ".claude", ".credentials.json")
+		if err := os.MkdirAll(filepath.Dir(dst), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dst, []byte("original"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		err := store.OverwriteFile("claude-code", ".claude/.credentials.json", []byte("replacement"))
+		if err != nil {
+			t.Fatalf("OverwriteFile failed: %v", err)
+		}
+
+		data, err := os.ReadFile(dst)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "replacement" {
+			t.Fatalf("expected overwritten content, got: %s", data)
+		}
+	})
+
+	t.Run("rejects invalid agent name", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		err := store.OverwriteFile("../evil", ".claude/.credentials.json", []byte("x"))
+		if err == nil {
+			t.Fatal("expected error for invalid agent name")
+		}
+	})
+
+	t.Run("rejects path traversal", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := NewFSStore(baseDir, logger)
+
+		err := store.OverwriteFile("claude-code", "../escape/creds.json", []byte("evil"))
+		if err == nil {
+			t.Fatal("expected error for path traversal")
+		}
+	})
 }
 
 func TestContainedPath(t *testing.T) {

--- a/internal/infra/vm/mcpconfig.go
+++ b/internal/infra/vm/mcpconfig.go
@@ -54,6 +54,8 @@ type claudeCodeServer struct {
 
 // injectClaudeCodeMCP merges an MCP server entry into ~/.claude.json,
 // preserving any pre-existing keys (auth tokens, onboarding flags, etc.).
+// It also sets hasCompletedOnboarding so Claude Code skips the interactive
+// setup wizard, which cannot complete inside a headless VM.
 func injectClaudeCodeMCP(rootfsPath, gatewayIP string, port uint16, chown ChownFunc) error {
 	servers := map[string]claudeCodeServer{
 		"sandbox-tools": {
@@ -67,7 +69,11 @@ func injectClaudeCodeMCP(rootfsPath, gatewayIP string, port uint16, chown ChownF
 		return err
 	}
 
-	return mergeJSONKey(homeDir, ".claude.json", "mcpServers", servers, chown)
+	if err := mergeJSONKey(homeDir, ".claude.json", "mcpServers", servers, chown); err != nil {
+		return err
+	}
+
+	return mergeJSONKey(homeDir, ".claude.json", "hasCompletedOnboarding", true, chown)
 }
 
 // --- Codex ---

--- a/internal/infra/vm/mcpconfig_test.go
+++ b/internal/infra/vm/mcpconfig_test.go
@@ -140,6 +140,24 @@ func TestInjectClaudeCodeMCP(t *testing.T) {
 	}
 }
 
+func TestInjectClaudeCodeMCP_SetsOnboardingFlag(t *testing.T) {
+	t.Parallel()
+
+	rootfs := setupRootfs(t)
+	chown, _ := recordingChown()
+	err := injectClaudeCodeMCP(rootfs, "192.168.127.1", 4483, chown)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(rootfs, sandboxHome, ".claude.json"))
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Contains(t, raw, "hasCompletedOnboarding")
+	assert.JSONEq(t, "true", string(raw["hasCompletedOnboarding"]))
+}
+
 func TestInjectClaudeCodeMCP_CustomPort(t *testing.T) {
 	t.Parallel()
 
@@ -173,8 +191,10 @@ func TestInjectClaudeCodeMCP_NoExtraFields(t *testing.T) {
 	var raw map[string]any
 	require.NoError(t, json.Unmarshal(data, &raw))
 
-	assert.Len(t, raw, 1, "top-level should have only mcpServers")
+	assert.Len(t, raw, 2, "top-level should have mcpServers and hasCompletedOnboarding")
 	assert.Contains(t, raw, "mcpServers")
+	assert.Contains(t, raw, "hasCompletedOnboarding")
+	assert.Equal(t, true, raw["hasCompletedOnboarding"])
 
 	servers := raw["mcpServers"].(map[string]any)
 	assert.Len(t, servers, 1, "should have only sandbox-tools")

--- a/pkg/domain/config/config.go
+++ b/pkg/domain/config/config.go
@@ -59,6 +59,11 @@ type AuthConfig struct {
 	// SaveCredentials controls whether agent credentials are saved.
 	// nil = default true.
 	SaveCredentials *bool `yaml:"save_credentials,omitempty"`
+
+	// SeedHostCredentials controls whether host credentials (e.g. macOS
+	// Keychain) are seeded into the VM before the agent starts.
+	// nil = default false.
+	SeedHostCredentials *bool `yaml:"seed_host_credentials,omitempty"`
 }
 
 // SaveCredentialsEnabled returns whether credential saving is enabled.
@@ -68,6 +73,15 @@ func (a AuthConfig) SaveCredentialsEnabled() bool {
 		return true
 	}
 	return *a.SaveCredentials
+}
+
+// SeedHostCredentialsEnabled returns whether host credential seeding is enabled.
+// Defaults to false when SeedHostCredentials is nil.
+func (a AuthConfig) SeedHostCredentialsEnabled() bool {
+	if a.SeedHostCredentials == nil {
+		return false
+	}
+	return *a.SeedHostCredentials
 }
 
 // RuntimeConfig configures host runtime dependency handling.
@@ -351,8 +365,13 @@ func MergeConfigs(global, local *Config) *Config {
 	// Git: local can only tighten (disable), not enable if globally disabled.
 	result.Git = mergeGitConfig(global.Git, local.Git)
 
-	// Auth.SaveCredentials: local value is IGNORED (security constraint).
-	// Global preserved — local config cannot change credential persistence.
+	// Auth: local values are IGNORED (security constraint).
+	// Explicitly preserve only global values to prevent workspace config
+	// from enabling credential persistence or host credential seeding.
+	result.Auth = AuthConfig{
+		SaveCredentials:     global.Auth.SaveCredentials,
+		SeedHostCredentials: global.Auth.SeedHostCredentials,
+	}
 
 	// Runtime: local overrides global when explicitly set.
 	result.Runtime = mergeRuntimeConfig(global.Runtime, local.Runtime)

--- a/pkg/domain/config/config_test.go
+++ b/pkg/domain/config/config_test.go
@@ -71,6 +71,18 @@ func TestMergeConfigs(t *testing.T) {
 			},
 		},
 		{
+			name: "auth.seed_host_credentials from local is ignored",
+			global: &Config{
+				Auth: AuthConfig{SeedHostCredentials: nil},
+			},
+			local: &Config{
+				Auth: AuthConfig{SeedHostCredentials: boolPtr(true)},
+			},
+			want: &Config{
+				Auth: AuthConfig{SeedHostCredentials: nil},
+			},
+		},
+		{
 			name: "exclude patterns are additive",
 			global: &Config{
 				Review: ReviewConfig{ExcludePatterns: []string{"*.log"}},
@@ -564,6 +576,27 @@ func TestToEgressHosts(t *testing.T) {
 		assert.Contains(t, err.Error(), "allow_hosts[0]")
 		assert.Contains(t, err.Error(), "bare wildcard")
 	})
+}
+
+func TestAuthConfig_SeedHostCredentialsEnabled(t *testing.T) {
+	t.Parallel()
+	// Defaults to false when nil.
+	var a AuthConfig
+	if a.SeedHostCredentialsEnabled() {
+		t.Fatal("expected default false")
+	}
+	// Explicit true.
+	tr := true
+	a.SeedHostCredentials = &tr
+	if !a.SeedHostCredentialsEnabled() {
+		t.Fatal("expected true")
+	}
+	// Explicit false.
+	f := false
+	a.SeedHostCredentials = &f
+	if a.SeedHostCredentialsEnabled() {
+		t.Fatal("expected false")
+	}
 }
 
 func TestMergeGitConfig(t *testing.T) {

--- a/pkg/domain/credential/credential.go
+++ b/pkg/domain/credential/credential.go
@@ -23,4 +23,20 @@ type Store interface {
 	// Extract copies credential files from the guest rootfs after the
 	// session ends, saving them for the next boot.
 	Extract(rootfsPath, agentName string, credentialPaths []string) error
+
+	// SeedFile writes a file into the credential store for an agent.
+	// relPath is relative to the agent's home (e.g. ".claude/.credentials.json").
+	// No-op if the file already exists in the store.
+	SeedFile(agentName, relPath string, content []byte) error
+
+	// ReadFile reads a file from the credential store for an agent.
+	// relPath is relative to the agent's home (e.g. ".claude/.credentials.json").
+	// Returns os.ErrNotExist if the file does not exist.
+	ReadFile(agentName, relPath string) ([]byte, error)
+
+	// OverwriteFile writes a file into the credential store for an agent,
+	// replacing any existing content. relPath is relative to the agent's
+	// home (e.g. ".claude/.credentials.json"). Unlike SeedFile, this
+	// always writes regardless of whether the file already exists.
+	OverwriteFile(agentName, relPath string, content []byte) error
 }

--- a/pkg/domain/credential/credential.go
+++ b/pkg/domain/credential/credential.go
@@ -23,7 +23,12 @@ type Store interface {
 	// Extract copies credential files from the guest rootfs after the
 	// session ends, saving them for the next boot.
 	Extract(rootfsPath, agentName string, credentialPaths []string) error
+}
 
+// FileStore provides CRUD access to individual credential files in the store.
+// Used by Seeder implementations to read and write credential files
+// independently of the VM lifecycle.
+type FileStore interface {
 	// SeedFile writes a file into the credential store for an agent.
 	// relPath is relative to the agent's home (e.g. ".claude/.credentials.json").
 	// No-op if the file already exists in the store.
@@ -41,8 +46,8 @@ type Store interface {
 	OverwriteFile(agentName, relPath string, content []byte) error
 }
 
-// CredentialSeeder seeds fresh credentials from the host into the store
+// Seeder seeds fresh credentials from the host into the file store
 // before VM boot. Each agent has a different implementation.
-type CredentialSeeder interface {
-	Seed(store Store) error
+type Seeder interface {
+	Seed(store FileStore) error
 }

--- a/pkg/domain/credential/credential.go
+++ b/pkg/domain/credential/credential.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package credential defines the Store interface for persisting agent
+// Package credential defines interfaces for persisting and seeding agent
 // authentication credentials across sandbox VM sessions.
 package credential
 
@@ -39,4 +39,10 @@ type Store interface {
 	// home (e.g. ".claude/.credentials.json"). Unlike SeedFile, this
 	// always writes regardless of whether the file already exists.
 	OverwriteFile(agentName, relPath string, content []byte) error
+}
+
+// CredentialSeeder seeds fresh credentials from the host into the store
+// before VM boot. Each agent has a different implementation.
+type CredentialSeeder interface {
+	Seed(store Store) error
 }


### PR DESCRIPTION
## Summary

- **Host credential seeding** — New `--seed-credentials` flag (and `auth.seed_host_credentials` config) opts in to reading OAuth tokens from the host (macOS Keychain or `~/.claude/.credentials.json`) and pre-populating the VM credential store. Eliminates the need for browser-based OAuth on first run inside the VM.
- **Onboarding skip** — Set `hasCompletedOnboarding` in `.claude.json` so Claude Code skips the interactive wizard inside headless VMs.

## Credential seeding design

Each agent gets a `Seeder` implementation (domain interface in `pkg/domain/credential`). `ClaudeCodeSeeder` reads the host Keychain/file, compares `expiresAt` with stored credentials, and writes only if fresher. The `Store` interface is extended with `SeedFile`, `ReadFile`, and `OverwriteFile` to support individual file operations needed by the seeder.

Security constraints:
- Opt-in only (default disabled)
- `seed_host_credentials` in workspace `.broodbox.yaml` is ignored (security warning printed)
- Credential size bounded to 64 KiB
- Keychain output trimmed before JSON validation
- Atomic writes (temp file + rename)