### PR TITLE
Guard Cedar policy attribute access with `has` operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	charm.land/glamour/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/adrg/xdg v0.5.3
+	github.com/cedar-policy/cedar-go v1.5.2
 	github.com/gofrs/flock v0.13.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
@@ -54,7 +55,6 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/cedar-policy/cedar-go v1.5.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect

--- a/internal/infra/mcp/profiles.go
+++ b/internal/infra/mcp/profiles.go
@@ -23,8 +23,16 @@ var observePolicies = []string{
 // safeToolsPolicies extend observe with annotation-based tool call permits.
 // Tools with readOnlyHint=true are allowed. Tools that are both non-destructive
 // (destructiveHint=false) and closed-world (openWorldHint=false) are also allowed.
-// Missing annotations cause the when clause to fail, resulting in Cedar's
-// default-deny — matching MCP spec conservative defaults without custom code.
+//
+// Each when clause uses Cedar's `has` operator to guard attribute access.
+// Without `has`, accessing a missing attribute is an evaluation error — Cedar
+// treats errors as "policy not satisfied", but toolhive's pre-flight check
+// treats ANY error as a hard deny for the tool. Many MCP servers (GitHub,
+// context7) set only some annotations, so unguarded access would incorrectly
+// block tools that have readOnlyHint=true but omit destructiveHint.
+//
+// Tools that omit all annotation attributes are still denied (none of the
+// `has` guards pass), preserving the conservative default-deny posture.
 var safeToolsPolicies = []string{
 	// All observe permits.
 	`permit(principal, action == Action::"list_tools", resource);`,
@@ -33,9 +41,9 @@ var safeToolsPolicies = []string{
 	`permit(principal, action == Action::"get_prompt", resource);`,
 	`permit(principal, action == Action::"read_resource", resource);`,
 	// Allow read-only tools.
-	`permit(principal, action == Action::"call_tool", resource) when { resource.readOnlyHint == true };`,
+	`permit(principal, action == Action::"call_tool", resource) when { resource has readOnlyHint && resource.readOnlyHint == true };`,
 	// Allow non-destructive AND closed-world tools.
-	`permit(principal, action == Action::"call_tool", resource) when { resource.destructiveHint == false && resource.openWorldHint == false };`,
+	`permit(principal, action == Action::"call_tool", resource) when { resource has destructiveHint && resource.destructiveHint == false && resource has openWorldHint && resource.openWorldHint == false };`,
 }
 
 // ResolveProfile returns Cedar policy strings for the given authz config.

--- a/internal/infra/mcp/profiles_test.go
+++ b/internal/infra/mcp/profiles_test.go
@@ -4,34 +4,139 @@
 package mcp
 
 import (
-	"strings"
+	"fmt"
 	"testing"
 
+	cedar "github.com/cedar-policy/cedar-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/brood-box/pkg/domain/config"
 )
 
-func TestResolveProfile(t *testing.T) {
+// toolAnnotations describes the MCP tool annotation hints attached to a Cedar
+// resource entity. nil pointers mean the attribute is absent (not set by the
+// MCP server), which is the scenario that triggers Cedar's `has` guard.
+type toolAnnotations struct {
+	readOnlyHint    *bool
+	destructiveHint *bool
+	openWorldHint   *bool
+}
+
+// toolScenario is a named annotation combination used across all profiles.
+type toolScenario struct {
+	name        string
+	annotations toolAnnotations
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// scenarios covers the six annotation combinations from the task description.
+var scenarios = []toolScenario{
+	{
+		name: "full annotations (safe read-only, closed-world)",
+		annotations: toolAnnotations{
+			readOnlyHint: boolPtr(true), destructiveHint: boolPtr(false), openWorldHint: boolPtr(false),
+		},
+	},
+	{
+		name: "read-only but open-world (like osv, oci-registry)",
+		annotations: toolAnnotations{
+			readOnlyHint: boolPtr(true), destructiveHint: boolPtr(false), openWorldHint: boolPtr(true),
+		},
+	},
+	{
+		name: "partial annotations — only readOnlyHint=true (like GitHub read tools, context7)",
+		annotations: toolAnnotations{
+			readOnlyHint: boolPtr(true),
+		},
+	},
+	{
+		name:        "no annotations at all (like the fetch MCP server)",
+		annotations: toolAnnotations{},
+	},
+	{
+		name: "destructive tool",
+		annotations: toolAnnotations{
+			readOnlyHint: boolPtr(false), destructiveHint: boolPtr(true), openWorldHint: boolPtr(false),
+		},
+	},
+	{
+		name: "write tool, non-destructive, closed-world",
+		annotations: toolAnnotations{
+			readOnlyHint: boolPtr(false), destructiveHint: boolPtr(false), openWorldHint: boolPtr(false),
+		},
+	},
+}
+
+// buildPolicySet parses a slice of Cedar policy strings into a PolicySet.
+func buildPolicySet(t *testing.T, policies []string) *cedar.PolicySet {
+	t.Helper()
+	ps := cedar.NewPolicySet()
+	for i, policyStr := range policies {
+		var p cedar.Policy
+		require.NoError(t, p.UnmarshalCedar([]byte(policyStr)), "parsing policy %d: %s", i, policyStr)
+		ps.Add(cedar.PolicyID(fmt.Sprintf("policy%d", i)), &p)
+	}
+	return ps
+}
+
+// buildEntities creates a Cedar EntityMap with principal, action, and resource
+// entities. Resource attributes are populated from the given annotations,
+// mirroring how toolhive's annotation enrichment works: only non-nil hints
+// are added as attributes.
+func buildEntities(
+	principal, action, resource cedar.EntityUID,
+	ann toolAnnotations,
+) cedar.EntityMap {
+	attrs := cedar.RecordMap{}
+	if ann.readOnlyHint != nil {
+		attrs[cedar.String("readOnlyHint")] = cedar.Boolean(*ann.readOnlyHint)
+	}
+	if ann.destructiveHint != nil {
+		attrs[cedar.String("destructiveHint")] = cedar.Boolean(*ann.destructiveHint)
+	}
+	if ann.openWorldHint != nil {
+		attrs[cedar.String("openWorldHint")] = cedar.Boolean(*ann.openWorldHint)
+	}
+	return cedar.EntityMap{
+		principal: {
+			UID:        principal,
+			Parents:    cedar.NewEntityUIDSet(),
+			Attributes: cedar.NewRecord(cedar.RecordMap{}),
+			Tags:       cedar.NewRecord(cedar.RecordMap{}),
+		},
+		action: {
+			UID:        action,
+			Parents:    cedar.NewEntityUIDSet(),
+			Attributes: cedar.NewRecord(cedar.RecordMap{}),
+			Tags:       cedar.NewRecord(cedar.RecordMap{}),
+		},
+		resource: {
+			UID:        resource,
+			Parents:    cedar.NewEntityUIDSet(),
+			Attributes: cedar.NewRecord(attrs),
+			Tags:       cedar.NewRecord(cedar.RecordMap{}),
+		},
+	}
+}
+
+func TestResolveProfileReturns(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		cfg          *config.MCPAuthzConfig
-		wantNil      bool
-		wantCount    int
-		wantErr      string
-		wantContains []string
-		wantAbsent   []string
+		name    string
+		cfg     *config.MCPAuthzConfig
+		wantNil bool
+		wantErr string
 	}{
 		{
-			name:    "nil config returns nil policies (full-access default)",
+			name:    "nil config returns nil policies",
 			cfg:     nil,
 			wantNil: true,
 		},
 		{
-			name:    "empty profile returns nil policies (full-access default)",
+			name:    "empty profile returns nil policies",
 			cfg:     &config.MCPAuthzConfig{Profile: ""},
 			wantNil: true,
 		},
@@ -41,33 +146,17 @@ func TestResolveProfile(t *testing.T) {
 			wantNil: true,
 		},
 		{
-			name:      "observe returns 5 list/read permits",
-			cfg:       &config.MCPAuthzConfig{Profile: config.MCPAuthzProfileObserve},
-			wantCount: 5,
-			wantContains: []string{
-				`Action::"list_tools"`,
-				`Action::"list_prompts"`,
-				`Action::"list_resources"`,
-				`Action::"get_prompt"`,
-				`Action::"read_resource"`,
-			},
-			wantAbsent: []string{
-				`Action::"call_tool"`,
-			},
+			name:    "observe returns non-nil policies",
+			cfg:     &config.MCPAuthzConfig{Profile: config.MCPAuthzProfileObserve},
+			wantNil: false,
 		},
 		{
-			name:      "safe-tools returns 7 policies (5 observe + 2 annotation-based)",
-			cfg:       &config.MCPAuthzConfig{Profile: config.MCPAuthzProfileSafeTools},
-			wantCount: 7,
-			wantContains: []string{
-				`Action::"list_tools"`,
-				`Action::"call_tool"`,
-				`resource.readOnlyHint == true`,
-				`resource.destructiveHint == false && resource.openWorldHint == false`,
-			},
+			name:    "safe-tools returns non-nil policies",
+			cfg:     &config.MCPAuthzConfig{Profile: config.MCPAuthzProfileSafeTools},
+			wantNil: false,
 		},
 		{
-			name:    "custom profile returns error (must be resolved by provider)",
+			name:    "custom profile returns error",
 			cfg:     &config.MCPAuthzConfig{Profile: config.MCPAuthzProfileCustom},
 			wantErr: "custom profile must be resolved from vmcp config",
 		},
@@ -81,33 +170,156 @@ func TestResolveProfile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
 			policies, err := ResolveProfile(tt.cfg)
-
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
 				return
 			}
-
 			require.NoError(t, err)
-
 			if tt.wantNil {
 				assert.Nil(t, policies)
-				return
-			}
-
-			assert.Len(t, policies, tt.wantCount)
-
-			joined := strings.Join(policies, "\n")
-
-			for _, want := range tt.wantContains {
-				assert.Contains(t, joined, want)
-			}
-			for _, absent := range tt.wantAbsent {
-				assert.NotContains(t, joined, absent)
+			} else {
+				assert.NotEmpty(t, policies)
 			}
 		})
+	}
+}
+
+func TestCedarAuthorizationDecisions(t *testing.T) {
+	t.Parallel()
+
+	principal := cedar.NewEntityUID("Client", "test-agent")
+
+	type actionExpect struct {
+		action string
+		want   cedar.Decision
+	}
+
+	type profileCase struct {
+		profile string
+		expect  []actionExpect
+	}
+
+	tests := []struct {
+		scenario    toolScenario
+		profileExps []profileCase
+	}{
+		{
+			scenario: scenarios[0], // full annotations (safe read-only, closed-world)
+			profileExps: []profileCase{
+				{profile: config.MCPAuthzProfileObserve, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Deny},
+				}},
+				{profile: config.MCPAuthzProfileSafeTools, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Allow},
+				}},
+			},
+		},
+		{
+			scenario: scenarios[1], // read-only but open-world
+			profileExps: []profileCase{
+				{profile: config.MCPAuthzProfileObserve, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Deny},
+				}},
+				{profile: config.MCPAuthzProfileSafeTools, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Allow}, // readOnlyHint=true permits
+				}},
+			},
+		},
+		{
+			scenario: scenarios[2], // partial annotations — only readOnlyHint=true
+			profileExps: []profileCase{
+				{profile: config.MCPAuthzProfileObserve, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Deny},
+				}},
+				{profile: config.MCPAuthzProfileSafeTools, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Allow}, // Bug catch: without `has` guards this would be Deny
+				}},
+			},
+		},
+		{
+			scenario: scenarios[3], // no annotations at all
+			profileExps: []profileCase{
+				{profile: config.MCPAuthzProfileObserve, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Deny},
+				}},
+				{profile: config.MCPAuthzProfileSafeTools, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Deny}, // no hints → no `has` guards pass → default deny
+				}},
+			},
+		},
+		{
+			scenario: scenarios[4], // destructive tool
+			profileExps: []profileCase{
+				{profile: config.MCPAuthzProfileObserve, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Deny},
+				}},
+				{profile: config.MCPAuthzProfileSafeTools, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Deny}, // readOnly=false, destructive=true → both policies deny
+				}},
+			},
+		},
+		{
+			scenario: scenarios[5], // write tool, non-destructive, closed-world
+			profileExps: []profileCase{
+				{profile: config.MCPAuthzProfileObserve, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Deny},
+				}},
+				{profile: config.MCPAuthzProfileSafeTools, expect: []actionExpect{
+					{"list_tools", cedar.Allow},
+					{"call_tool", cedar.Allow}, // destructive=false && openWorld=false → second policy permits
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, pc := range tt.profileExps {
+			for _, ae := range pc.expect {
+				name := fmt.Sprintf("%s/%s/%s", pc.profile, tt.scenario.name, ae.action)
+				t.Run(name, func(t *testing.T) {
+					t.Parallel()
+
+					policies, err := ResolveProfile(&config.MCPAuthzConfig{Profile: pc.profile})
+					require.NoError(t, err)
+					require.NotNil(t, policies)
+
+					ps := buildPolicySet(t, policies)
+					actionUID := cedar.NewEntityUID("Action", cedar.String(ae.action))
+					resourceUID := cedar.NewEntityUID("Tool", "test-tool")
+					entities := buildEntities(principal, actionUID, resourceUID, tt.scenario.annotations)
+
+					req := cedar.Request{
+						Principal: principal,
+						Action:    actionUID,
+						Resource:  resourceUID,
+						Context:   cedar.NewRecord(cedar.RecordMap{}),
+					}
+
+					decision, diag := cedar.Authorize(ps, entities, req)
+
+					// Cedar evaluation errors indicate a bug in the policies
+					// (e.g., accessing an attribute that doesn't exist without
+					// a `has` guard). The whole point of this test is to catch
+					// that, so fail hard on any error.
+					assert.Empty(t, diag.Errors, "Cedar evaluation errors (likely missing `has` guard)")
+					assert.Equal(t, ae.want, decision,
+						"profile=%s scenario=%q action=%s", pc.profile, tt.scenario.name, ae.action)
+				})
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix safe-tools Cedar policies to use `resource has <attr> &&` guards before accessing tool annotation attributes
- Without guards, MCP servers that set partial annotations (e.g. GitHub sets `readOnlyHint` but not `destructiveHint`) had all their tools incorrectly denied — Cedar treats missing attribute access as an evaluation error, and toolhive's pre-flight check treats any error as a hard deny
- Rewrite `profiles_test.go` to exercise the actual Cedar engine against 6 annotation scenarios × 2 profiles × 2 actions (24 cases), replacing substring-matching tests that wouldn't have caught this bug

**Before:** safe-tools allowed only 7 tools (osv + oci-registry — the only servers with complete annotations)
**After:** safe-tools allows 59 tools (all read-only tools from GitHub, context7, osv, oci-registry)

## Test plan

- [x] `task verify` passes (fmt, lint, test)
- [x] `TestCedarAuthorizationDecisions` covers the exact partial-annotation scenario that was broken (scenario 3: only `readOnlyHint=true`, no other hints)
- [x] Verified end-to-end with a debug harness against live MCP servers (osv, oci-registry, github, context7, fetch, slack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)