### PR TITLE
Resolve git config path for worktree workspaces

### DIFF
--- a/internal/infra/credential/claudeseeder.go
+++ b/internal/infra/credential/claudeseeder.go
@@ -31,9 +31,9 @@ const keychainService = "Claude Code-credentials"
 //   - No credentials exist yet (first run), or
 //   - The stored access token has expired and the host has a fresher one.
 type ClaudeCodeSeeder struct {
-	logger    *slog.Logger
-	readHost  func() ([]byte, string, error) // reads host credentials
-	nowMs     func() int64                   // current time in epoch ms
+	logger   *slog.Logger
+	readHost func() ([]byte, string, error) // reads host credentials
+	nowMs    func() int64                   // current time in epoch ms
 }
 
 // NewClaudeCodeSeeder creates a new ClaudeCodeSeeder with production defaults.

--- a/internal/infra/git/sanitizer.go
+++ b/internal/infra/git/sanitizer.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/stacklok/brood-box/pkg/domain/workspace"
 )
@@ -45,9 +46,19 @@ func NewConfigSanitizer(logger *slog.Logger) *ConfigSanitizer {
 }
 
 // Process reads .git/config from originalPath, sanitizes it, and writes
-// the result into snapshotPath/.git/config.
+// the result into snapshotPath/.git/config. Supports both normal repos
+// (where .git is a directory) and git worktrees (where .git is a file
+// pointing to the main repo's gitdir).
 func (s *ConfigSanitizer) Process(_ context.Context, originalPath, snapshotPath string) error {
-	srcPath := filepath.Join(originalPath, ".git", "config")
+	srcPath, err := resolveGitConfigPath(originalPath)
+	if err != nil {
+		s.logger.Warn("could not resolve git config path, skipping sanitization",
+			"path", originalPath, "error", err)
+		return nil
+	}
+	if srcPath == "" {
+		return nil
+	}
 
 	data, err := os.ReadFile(srcPath)
 	if err != nil {
@@ -60,6 +71,13 @@ func (s *ConfigSanitizer) Process(_ context.Context, originalPath, snapshotPath 
 	sanitized := SanitizeConfig(string(data))
 
 	dstDir := filepath.Join(snapshotPath, ".git")
+
+	// In worktree snapshots, .git may be a file (the worktree pointer).
+	// Remove it so MkdirAll can create the directory.
+	if err := removeIfFile(dstDir); err != nil {
+		return fmt.Errorf("removing .git file in snapshot: %w", err)
+	}
+
 	if err := os.MkdirAll(dstDir, 0o755); err != nil {
 		return fmt.Errorf("creating .git directory in snapshot: %w", err)
 	}
@@ -70,6 +88,86 @@ func (s *ConfigSanitizer) Process(_ context.Context, originalPath, snapshotPath 
 	}
 
 	return nil
+}
+
+// resolveGitConfigPath returns the path to the git config file for the
+// given workspace. It handles both normal repos (.git is a directory)
+// and worktrees (.git is a file with a gitdir pointer).
+//
+// Returns ("", nil) if there is no .git entry (not a git repo).
+func resolveGitConfigPath(workspacePath string) (string, error) {
+	dotGitPath := filepath.Join(workspacePath, ".git")
+
+	data, err := os.ReadFile(dotGitPath)
+	if err == nil {
+		// .git is a file — this is a worktree.
+		return resolveWorktreeConfigPath(workspacePath, data)
+	}
+
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
+
+	if errors.Is(err, syscall.EISDIR) {
+		// .git is a directory — normal repo.
+		return filepath.Join(dotGitPath, "config"), nil
+	}
+
+	return "", fmt.Errorf("reading .git: %w", err)
+}
+
+// resolveWorktreeConfigPath parses the worktree .git file content and
+// resolves through the commondir file to find the shared git config.
+func resolveWorktreeConfigPath(workspacePath string, dotGitData []byte) (string, error) {
+	content := strings.TrimSpace(string(dotGitData))
+	if !strings.HasPrefix(content, "gitdir: ") {
+		return "", fmt.Errorf("malformed .git file: missing 'gitdir: ' prefix")
+	}
+
+	gitdir := strings.TrimPrefix(content, "gitdir: ")
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(workspacePath, gitdir)
+	}
+	gitdir = filepath.Clean(gitdir)
+
+	// Try to read the commondir file to find the shared .git directory.
+	commondirData, err := os.ReadFile(filepath.Join(gitdir, "commondir"))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// No commondir — fall back to gitdir/config (submodules, etc.).
+			return filepath.Join(gitdir, "config"), nil
+		}
+		return "", fmt.Errorf("reading commondir: %w", err)
+	}
+
+	commondir := strings.TrimSpace(string(commondirData))
+	if !filepath.IsAbs(commondir) {
+		commondir = filepath.Join(gitdir, commondir)
+	}
+	commondir = filepath.Clean(commondir)
+
+	// Defense-in-depth: verify the resolved path looks like a git directory.
+	if _, err := os.Stat(filepath.Join(commondir, "HEAD")); err != nil {
+		return "", fmt.Errorf("resolved commondir %q does not contain HEAD: %w", commondir, err)
+	}
+
+	return filepath.Join(commondir, "config"), nil
+}
+
+// removeIfFile removes the path if it exists and is not a directory.
+// No-op if the path does not exist or is already a directory.
+func removeIfFile(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.IsDir() {
+		return nil
+	}
+	return os.Remove(path)
 }
 
 // SanitizeConfig parses a git config file and returns a sanitized version

--- a/internal/infra/git/sanitizer_test.go
+++ b/internal/infra/git/sanitizer_test.go
@@ -494,3 +494,227 @@ func TestContainsCredentials_FileHandling(t *testing.T) {
 		assert.False(t, hasCreds)
 	})
 }
+
+func TestResolveGitConfigPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normal repo returns .git/config", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		gitDir := filepath.Join(dir, ".git")
+		require.NoError(t, os.MkdirAll(gitDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte("[core]\n"), 0o644))
+
+		path, err := resolveGitConfigPath(dir)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(gitDir, "config"), path)
+	})
+
+	t.Run("no git returns empty", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		path, err := resolveGitConfigPath(dir)
+		require.NoError(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("worktree resolves through commondir", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up a main repo .git directory.
+		mainRepo := t.TempDir()
+		mainGitDir := filepath.Join(mainRepo, ".git")
+		require.NoError(t, os.MkdirAll(filepath.Join(mainGitDir, "worktrees", "wt1"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(mainGitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(mainGitDir, "config"), []byte("[core]\n\tbare = false\n"), 0o644))
+
+		// Set up commondir in the worktree gitdir.
+		wtGitDir := filepath.Join(mainGitDir, "worktrees", "wt1")
+		require.NoError(t, os.WriteFile(filepath.Join(wtGitDir, "commondir"), []byte("../..\n"), 0o644))
+
+		// Set up worktree workspace with .git file.
+		wtWorkspace := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(wtWorkspace, ".git"),
+			[]byte("gitdir: "+wtGitDir+"\n"),
+			0o644,
+		))
+
+		path, err := resolveGitConfigPath(wtWorkspace)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(mainGitDir, "config"), path)
+	})
+
+	t.Run("worktree with relative commondir", func(t *testing.T) {
+		t.Parallel()
+
+		mainRepo := t.TempDir()
+		mainGitDir := filepath.Join(mainRepo, ".git")
+		require.NoError(t, os.MkdirAll(filepath.Join(mainGitDir, "worktrees", "wt1"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(mainGitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(mainGitDir, "config"), []byte("[core]\n"), 0o644))
+
+		wtGitDir := filepath.Join(mainGitDir, "worktrees", "wt1")
+		// Relative commondir (standard git worktree layout).
+		require.NoError(t, os.WriteFile(filepath.Join(wtGitDir, "commondir"), []byte("../.."), 0o644))
+
+		wtWorkspace := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(wtWorkspace, ".git"),
+			[]byte("gitdir: "+wtGitDir+"\n"),
+			0o644,
+		))
+
+		path, err := resolveGitConfigPath(wtWorkspace)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(mainGitDir, "config"), path)
+	})
+
+	t.Run("malformed .git file returns error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".git"), []byte("garbage content\n"), 0o644))
+
+		_, err := resolveGitConfigPath(dir)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "malformed .git file")
+	})
+
+	t.Run("worktree without commondir falls back to gitdir/config", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up a gitdir without a commondir file (e.g. submodule).
+		gitdir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(gitdir, "config"), []byte("[core]\n"), 0o644))
+
+		wtWorkspace := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(wtWorkspace, ".git"),
+			[]byte("gitdir: "+gitdir+"\n"),
+			0o644,
+		))
+
+		path, err := resolveGitConfigPath(wtWorkspace)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(gitdir, "config"), path)
+	})
+
+	t.Run("broken gitdir path returns error", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, ".git"),
+			[]byte("gitdir: /nonexistent/path/that/does/not/exist\n"),
+			0o644,
+		))
+
+		// commondir won't exist → falls back to gitdir/config, which also
+		// won't exist. resolveGitConfigPath still returns a path (it doesn't
+		// verify the config file exists — that's Process's job).
+		path, err := resolveGitConfigPath(dir)
+		require.NoError(t, err)
+		assert.Equal(t, "/nonexistent/path/that/does/not/exist/config", path)
+	})
+}
+
+func TestProcess_Worktree(t *testing.T) {
+	t.Parallel()
+
+	// Set up a main repo with .git directory.
+	mainRepo := t.TempDir()
+	mainGitDir := filepath.Join(mainRepo, ".git")
+	require.NoError(t, os.MkdirAll(filepath.Join(mainGitDir, "worktrees", "wt1"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(mainGitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644))
+
+	configContent := strings.Join([]string{
+		"[core]",
+		"\tbare = false",
+		"[credential]",
+		"\thelper = store",
+		`[remote "origin"]`,
+		"\turl = https://user:token@github.com/org/repo.git",
+	}, "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(mainGitDir, "config"), []byte(configContent), 0o644))
+
+	// Set up worktree gitdir with commondir.
+	wtGitDir := filepath.Join(mainGitDir, "worktrees", "wt1")
+	require.NoError(t, os.WriteFile(filepath.Join(wtGitDir, "commondir"), []byte("../.."), 0o644))
+
+	// Original workspace: .git is a file.
+	originalDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(originalDir, ".git"),
+		[]byte("gitdir: "+wtGitDir+"\n"),
+		0o644,
+	))
+
+	// Snapshot: also has .git as a file (mimicking snapshot walker behavior).
+	snapshotDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(snapshotDir, ".git"),
+		[]byte("gitdir: "+wtGitDir+"\n"),
+		0o644,
+	))
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	sanitizer := NewConfigSanitizer(logger)
+
+	err := sanitizer.Process(context.Background(), originalDir, snapshotDir)
+	require.NoError(t, err)
+
+	// The .git should now be a directory with a sanitized config.
+	info, err := os.Stat(filepath.Join(snapshotDir, ".git"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	result, err := os.ReadFile(filepath.Join(snapshotDir, ".git", "config"))
+	require.NoError(t, err)
+
+	expected := strings.Join([]string{
+		"[core]",
+		"\tbare = false",
+		`[remote "origin"]`,
+		"\turl = https://github.com/org/repo.git",
+	}, "\n")
+	assert.Equal(t, expected, string(result))
+}
+
+func TestProcess_WorktreeNoCommondir(t *testing.T) {
+	t.Parallel()
+
+	// Set up a gitdir without commondir (e.g. submodule).
+	gitdir := t.TempDir()
+	configContent := strings.Join([]string{
+		"[core]",
+		"\tbare = false",
+		"[credential]",
+		"\thelper = store",
+	}, "\n")
+	require.NoError(t, os.WriteFile(filepath.Join(gitdir, "config"), []byte(configContent), 0o644))
+
+	// Original workspace: .git is a file pointing to gitdir.
+	originalDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(originalDir, ".git"),
+		[]byte("gitdir: "+gitdir+"\n"),
+		0o644,
+	))
+
+	snapshotDir := t.TempDir()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	sanitizer := NewConfigSanitizer(logger)
+
+	err := sanitizer.Process(context.Background(), originalDir, snapshotDir)
+	require.NoError(t, err)
+
+	result, err := os.ReadFile(filepath.Join(snapshotDir, ".git", "config"))
+	require.NoError(t, err)
+
+	expected := strings.Join([]string{
+		"[core]",
+		"\tbare = false",
+	}, "\n")
+	assert.Equal(t, expected, string(result))
+}


### PR DESCRIPTION
In a worktree .git is a file pointing to the main repo's gitdir, not a directory. ReadFile(.git) to detect this, follow the gitdir and commondir chain to the shared config, and replace the stale pointer file in the snapshot so MkdirAll can create .git/config.