### PR TITLE
Exclude .git from diff to prevent worktree breakage

### DIFF
--- a/internal/infra/exclude/loader.go
+++ b/internal/infra/exclude/loader.go
@@ -35,10 +35,11 @@ func LoadExcludeConfig(workspacePath string, cliPatterns []string, logger *slog.
 	}
 
 	return snapshot.ExcludeConfig{
-		SecurityPatterns:    securityPatterns,
-		PerformancePatterns: perfPatterns,
-		FilePatterns:        filePatterns,
-		CLIPatterns:         cliPatterns,
+		SecurityPatterns:     securityPatterns,
+		DiffSecurityPatterns: snapshot.DefaultDiffSecurityPatterns(),
+		PerformancePatterns:  perfPatterns,
+		FilePatterns:         filePatterns,
+		CLIPatterns:          cliPatterns,
 	}, nil
 }
 
@@ -65,7 +66,11 @@ func NewDiffMatcher(cfg snapshot.ExcludeConfig, gitignorePatterns []string) snap
 	userAndPerf = append(userAndPerf, cfg.CLIPatterns...)
 	userAndPerf = append(userAndPerf, gitignorePatterns...)
 
-	return NewMatcher(userAndPerf, cfg.SecurityPatterns)
+	allSecurity := make([]string, 0, len(cfg.SecurityPatterns)+len(cfg.DiffSecurityPatterns))
+	allSecurity = append(allSecurity, cfg.SecurityPatterns...)
+	allSecurity = append(allSecurity, cfg.DiffSecurityPatterns...)
+
+	return NewMatcher(userAndPerf, allSecurity)
 }
 
 // readIgnoreFile reads a .broodboxignore file and returns the cleaned patterns.

--- a/internal/infra/exclude/loader_test.go
+++ b/internal/infra/exclude/loader_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/brood-box/pkg/domain/snapshot"
 )
 
 func TestLoadExcludeConfig_NoFile(t *testing.T) {
@@ -23,6 +25,7 @@ func TestLoadExcludeConfig_NoFile(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, cfg.SecurityPatterns)
+	assert.NotEmpty(t, cfg.DiffSecurityPatterns)
 	assert.NotEmpty(t, cfg.PerformancePatterns)
 	assert.Empty(t, cfg.FilePatterns)
 	assert.Empty(t, cfg.CLIPatterns)
@@ -73,6 +76,42 @@ func TestLoadExcludeConfig_CLIPatterns(t *testing.T) {
 	assert.Equal(t, []string{"*.bak", "temp/"}, cfg.CLIPatterns)
 }
 
+func TestNewDiffMatcher_MergesDiffSecurityPatterns(t *testing.T) {
+	t.Parallel()
+
+	cfg := snapshot.ExcludeConfig{
+		SecurityPatterns:     snapshot.DefaultSecurityPatterns(),
+		DiffSecurityPatterns: snapshot.DefaultDiffSecurityPatterns(),
+		PerformancePatterns:  snapshot.DefaultPerformancePatterns(),
+	}
+
+	m := NewDiffMatcher(cfg, nil)
+
+	// Shared security pattern should match.
+	assert.True(t, m.Match(".env"), "shared security pattern .env should match")
+	// Diff-only security pattern should match .git file (worktree pointer).
+	assert.True(t, m.Match(".git"), "diff security pattern .git should match")
+	// Diff-only security pattern should match .git/ directory contents.
+	assert.True(t, m.Match(".git/hooks/pre-commit"), ".git/ contents should match via diff security")
+	// Regular file should not match.
+	assert.False(t, m.Match("main.go"), "regular file should not match")
+}
+
+func TestNewDiffMatcher_GitignorePatternsIncluded(t *testing.T) {
+	t.Parallel()
+
+	cfg := snapshot.ExcludeConfig{
+		SecurityPatterns:     snapshot.DefaultSecurityPatterns(),
+		DiffSecurityPatterns: snapshot.DefaultDiffSecurityPatterns(),
+	}
+
+	m := NewDiffMatcher(cfg, []string{"*.o", "build/"})
+
+	// Gitignore patterns should match.
+	assert.True(t, m.Match("foo.o"), "gitignore pattern *.o should match")
+	assert.True(t, m.Match("build/output"), "gitignore pattern build/ should match")
+}
+
 func TestNewMatcherFromConfig(t *testing.T) {
 	t.Parallel()
 
@@ -90,4 +129,7 @@ func TestNewMatcherFromConfig(t *testing.T) {
 	assert.True(t, m.Match("node_modules/foo.js"))
 	// Regular file should not match.
 	assert.False(t, m.Match("main.go"))
+	// .git must NOT be excluded in snapshot matcher — agent needs it for git operations.
+	// Only the diff matcher (NewDiffMatcher) should exclude .git.
+	assert.False(t, m.Match(".git"), ".git should not be excluded in snapshot matcher")
 }

--- a/pkg/domain/snapshot/exclude.go
+++ b/pkg/domain/snapshot/exclude.go
@@ -9,6 +9,12 @@ type ExcludeConfig struct {
 	// These cannot be negated by user patterns.
 	SecurityPatterns []string
 
+	// DiffSecurityPatterns are additional non-overridable patterns
+	// applied only during diff/flush. These prevent agent modifications
+	// to files that must exist in the snapshot but should never be
+	// flushed back (e.g. .git in worktrees).
+	DiffSecurityPatterns []string
+
 	// PerformancePatterns are built-in patterns that can be
 	// overridden via negation in .broodboxignore.
 	PerformancePatterns []string
@@ -59,6 +65,7 @@ func DefaultSecurityPatterns() []string {
 		".config/gcloud/",
 		// Credential files
 		"credentials.json",
+		".git-credentials",
 		".netrc",
 		".npmrc",
 		".yarnrc.yml",
@@ -82,6 +89,20 @@ func DefaultSecurityPatterns() []string {
 		".broodbox.yaml",
 		// Brood Box agent state (saved credentials).
 		".config/broodbox/",
+	}
+}
+
+// DefaultDiffSecurityPatterns returns non-overridable patterns applied only
+// during diff/flush. These protect files that must exist in the snapshot
+// (the agent needs them) but should never be diffed or flushed back.
+func DefaultDiffSecurityPatterns() []string {
+	return []string{
+		// Covers .git file (worktree pointer) and .git/ directory + contents.
+		// The agent needs .git in the snapshot for git operations, but nothing
+		// under .git is agent output and must not be flushed back. Without this,
+		// the sanitizer's replacement of the .git worktree file with a directory
+		// causes the differ to mark the original .git file as deleted.
+		".git",
 	}
 }
 

--- a/pkg/domain/snapshot/exclude_test.go
+++ b/pkg/domain/snapshot/exclude_test.go
@@ -50,6 +50,7 @@ func TestDefaultSecurityPatterns(t *testing.T) {
 		".gcloud/",
 		".config/gcloud/",
 		"credentials.json",
+		".git-credentials",
 		".yarnrc.yml",
 		".docker/config.json",
 		".git/config",
@@ -65,6 +66,14 @@ func TestDefaultSecurityPatterns(t *testing.T) {
 	for _, pat := range expected {
 		assert.Contains(t, patterns, pat, "missing security pattern: %s", pat)
 	}
+}
+
+func TestDefaultDiffSecurityPatterns(t *testing.T) {
+	t.Parallel()
+
+	patterns := DefaultDiffSecurityPatterns()
+	assert.NotEmpty(t, patterns)
+	assert.Contains(t, patterns, ".git", "diff security patterns must exclude .git")
 }
 
 func TestDefaultPerformancePatterns(t *testing.T) {


### PR DESCRIPTION
The git config sanitizer replaces the .git worktree pointer file with a .git/ directory in the snapshot. The differ then marks the original .git file as deleted, and the flusher removes it from the real workspace — breaking the worktree.

Fix by adding a DiffSecurityPatterns concept: patterns that apply only during diff/flush but not during snapshot creation. The .git pattern covers both the worktree pointer file and the .git/ directory, so nothing under .git is ever diffed or flushed back.

Also adds .git-credentials to shared security patterns.