### PR TITLE
Fix stale and incomplete documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,14 +47,22 @@ This project follows DDD layered architecture with dependency injection **strict
 
 **Domain** (`pkg/domain/`) — Pure types and interfaces. ZERO I/O, ZERO external dependencies, ZERO side effects. Domain packages define _what_ things are and _what_ operations exist, never _how_ they are performed. Public so external modules can import the shared ubiquitous language:
 - `pkg/domain/agent/` — Agent value object, env forwarding
-- `pkg/domain/config/` — Config types, merge logic
+- `pkg/domain/config/` — Config types, merge logic, ByteSize parsing
 - `pkg/domain/vm/` — VMRunner, VM, VMConfig interfaces
 - `pkg/domain/session/` — TerminalSession interface
 - `pkg/domain/workspace/` — WorkspaceCloner interface, Snapshot type
 - `pkg/domain/snapshot/` — FileChange, ExcludeConfig, Matcher, Differ, Reviewer, Flusher
+- `pkg/domain/credential/` — Store, FileStore, Seeder interfaces
+- `pkg/domain/egress/` — DNS-aware egress Policy, Host, ProfileName, Resolve()
+- `pkg/domain/git/` — Identity, IdentityProvider interface
+- `pkg/domain/hostservice/` — Service, Provider for HTTP services exposed to guest
+- `pkg/domain/progress/` — Phase enum, Observer interface for lifecycle reporting
 
 **Application** (`pkg/sandbox/`) — Orchestration only. Depends on domain interfaces, never on infrastructure. Contains no I/O implementations. Public so library consumers can drive the same SandboxRunner API:
 - `pkg/sandbox/` — SandboxRunner orchestrator (application service), SandboxConfig SDK contract
+
+**Runtime Factory** (`pkg/runtime/`) — Public helper that wires default infrastructure for SDK consumers. Keeps `internal/infra/` private while providing a supported path to construct `SandboxRunner` with standard implementations:
+- `pkg/runtime/` — `NewDefaultSandboxDeps()`, `NewDefaultSandboxRunner()`, exclude matcher builders
 
 **Infrastructure** (`internal/infra/`) — Concrete implementations of domain interfaces. This is the only layer that touches I/O, external libraries, and system calls:
 - `internal/infra/vm/` — go-microvm VMRunner implementation, rootfs hooks
@@ -66,10 +74,16 @@ This project follows DDD layered architecture with dependency injection **strict
 - `internal/infra/workspace/` — COW workspace cloning (FICLONE on Linux, clonefile on macOS, copy fallback)
 - `internal/infra/diff/` — SHA-256 based file diff engine
 - `internal/infra/review/` — Interactive per-file terminal review, auto-accept reviewer, flusher with hash verification
+- `internal/infra/credential/` — FS-based credential store, Claude credential seeder
+- `internal/infra/git/` — Host identity provider, `.git/config` credential sanitizer
+- `internal/infra/logging/` — Custom slog file handler
+- `internal/infra/terminal/` — OS terminal wrapper (raw mode, SIGWINCH)
+- `internal/infra/progress/` — Spinner, simple, and log-based progress observers
+- `internal/infra/process/` — Process management utilities
 
-**Guest VM** (`internal/guest/`, Linux only — runs inside the microVM):
-- `internal/guest/` — Boot, mount, network, env, sshd, reaper packages
-- `cmd/bbox-init/` — Guest PID 1 init binary (compiled Go)
+**Guest VM** (`internal/guest/` + `cmd/bbox-init/`, Linux only — runs inside the microVM):
+- `internal/guest/homefs/` — Writable home directory overlay (overlayfs/tmpfs)
+- `cmd/bbox-init/` — Guest PID 1 init binary (compiled Go); boot, mount, network, env, sshd, and reaper logic lives in the go-microvm module under `guest/`
 
 **CLI + Composition Root** (`cmd/`):
 - `cmd/bbox/main.go` — Composition root, wires dependencies, Cobra CLI

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ bbox claude-code --cpus 4 --memory 4096
 # Use a different workspace
 bbox claude-code --workspace /path/to/project
 
-# Disable snapshot isolation (mount workspace directly)
-bbox claude-code --no-review
+# Enable interactive per-file review (snapshot isolation is always active)
+bbox claude-code --review
 
 # Exclude files from snapshot
 bbox claude-code --exclude "*.log" --exclude "tmp/"
@@ -250,9 +250,9 @@ bbox claude-code --allow-host "my-registry.example.com:443"
 
 | Agent | Command | Image | Default Resources |
 |---|---|---|---|
-| Claude Code | `bbox claude-code` | `ghcr.io/stacklok/brood-box/claude-code` | 2 vCPUs, 2 GiB RAM |
-| Codex | `bbox codex` | `ghcr.io/stacklok/brood-box/codex` | 2 vCPUs, 2 GiB RAM |
-| OpenCode | `bbox opencode` | `ghcr.io/stacklok/brood-box/opencode` | 2 vCPUs, 2 GiB RAM |
+| Claude Code | `bbox claude-code` | `ghcr.io/stacklok/brood-box/claude-code` | 2 vCPUs, 4 GiB RAM |
+| Codex | `bbox codex` | `ghcr.io/stacklok/brood-box/codex` | 2 vCPUs, 4 GiB RAM |
+| OpenCode | `bbox opencode` | `ghcr.io/stacklok/brood-box/opencode` | 2 vCPUs, 4 GiB RAM |
 
 You can also define custom agents in your config:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -266,10 +266,18 @@ bbox claude-code
    Diff → Review → Flush (if snapshot enabled) → Cleanup
 ```
 
-## Guest Layer (`internal/guest/`)
+## Guest Layer (`internal/guest/` + go-microvm `guest/`)
 
 Code that runs inside the microVM (Linux only, compiled into
-`cmd/bbox-init/`):
+`cmd/bbox-init/`).
+
+**In this repo** (`internal/guest/`):
+
+- **`homefs/`** -- Writable home directory overlay. Detects virtiofs
+  read-only issue and mounts overlayfs (tmpfs upper + virtiofs lower)
+  or tmpfs fallback. Probes writability as sandbox user.
+
+**In go-microvm** (`github.com/stacklok/go-microvm/guest/`):
 
 - **`boot/`** -- Orchestrates guest startup: mount filesystems,
   configure networking, mount workspace, load env, start SSH server.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -59,12 +59,12 @@ bbox <agent-name> [flags] [-- <agent-args...>]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--cpus` | Agent default (2) | Number of vCPUs for the VM |
-| `--memory` | Agent default (2048) | RAM in MiB |
+| `--memory` | Agent default (4096) | RAM in MiB |
 | `--workspace` | Current directory | Host directory mounted as `/workspace` |
 | `--ssh-port` | Auto-pick | Host port forwarded to guest SSH (port 22) |
 | `--config` | `~/.config/broodbox/config.yaml` | Config file path |
 | `--image` | Agent default | Override the OCI image reference |
-| `--no-review` | `false` | Disable snapshot isolation, mount workspace directly |
+| `--review` | `false` | Enable interactive per-file review of workspace changes (snapshot isolation is always active) |
 | `--exclude` | (none) | Additional gitignore-style exclude patterns (repeatable) |
 | `--egress-profile` | Agent default (`permissive`) | Egress restriction level: `permissive`, `standard`, `locked` |
 | `--allow-host` | (none) | Additional allowed egress DNS hostname[:port] — no IP addresses (repeatable) |
@@ -75,7 +75,13 @@ bbox <agent-name> [flags] [-- <agent-args...>]
 | `--mcp-authz-profile` | `full-access` | MCP authorization profile: `full-access`, `observe`, `safe-tools`, `custom` |
 | `--no-git-token` | `false` | Disable forwarding GITHUB_TOKEN/GH_TOKEN into the VM |
 | `--no-git-ssh-agent` | `false` | Disable SSH agent forwarding into the VM |
+| `--no-save-credentials` | `false` | Disable saving agent credentials between sessions |
+| `--seed-credentials` | `false` | Seed agent credentials from host (e.g. macOS Keychain) into the VM |
 | `--no-firmware-download` | `false` | Disable firmware download (use system libkrunfw only) |
+| `--no-image-cache` | `false` | Disable OCI image caching (fresh pull every run) |
+| `--tmp-size` | Agent default (512m) | Size of /tmp tmpfs inside the VM (e.g. `512m`, `2g`) |
+| `--exec` | Agent command | Override the agent command (e.g. `/bin/bash` for debugging) |
+| `--timings` | `false` | Print per-phase timing summary after run |
 | `--log-file` | `~/.config/broodbox/vms/<vm>/broodbox.log` | Override log file path |
 | `--debug` | `false` | Enable debug-level logging to file |
 
@@ -90,6 +96,8 @@ bbox claude-code -- --help
 | Command | Description |
 |---------|-------------|
 | `list` | List all available agents |
+| `auth list` | List agents with saved credentials |
+| `auth clear <agent>` | Remove saved credentials for an agent |
 
 ## What Happens When You Run It
 
@@ -229,13 +237,14 @@ Your workspace ──COW copy──▶ Snapshot directory
                         Accepted changes ──▶ Your workspace
 ```
 
-### Disabling Review
+### Enabling Interactive Review
 
-Pass `--no-review` to mount the workspace directly into the VM with no
-snapshot isolation:
+Snapshot isolation is always active. By default, all changes are
+auto-accepted (with auto-rejection of sensitive auto-exec paths).
+Pass `--review` to interactively approve or reject each changed file:
 
 ```bash
-bbox claude-code --no-review
+bbox claude-code --review
 ```
 
 ### Exclude Patterns


### PR DESCRIPTION
## Summary

Full documentation audit comparing all docs against the actual codebase. Fixes:

- **README.md**: Agent default RAM was listed as 2 GiB, actual is 4 GiB. Non-existent `--no-review` flag replaced with `--review`
- **USER_GUIDE.md**: Fixed default memory (2048 → 4096), replaced `--no-review` with `--review`, added 7 missing CLI flags (`--no-save-credentials`, `--seed-credentials`, `--no-image-cache`, `--tmp-size`, `--exec`, `--timings`), added `auth list`/`auth clear` subcommands, rewrote review section to reflect that snapshot isolation is always active
- **CLAUDE.md**: Added 5 missing domain packages (`credential/`, `egress/`, `git/`, `hostservice/`, `progress/`), 6 missing infra packages (`credential/`, `git/`, `logging/`, `terminal/`, `progress/`, `process/`), added `pkg/runtime/` layer, fixed `internal/guest/` description (only `homefs/` lives here; boot/mount/network/env/sshd/reaper are in go-microvm)
- **ARCHITECTURE.md**: Clarified guest layer split between this repo (`homefs/`) and go-microvm (`boot/`, `mount/`, `network/`, `env/`, `sshd/`, `reaper/`)
- Removed stale empty `pkg/infra/` directories left over from past migration

## Test plan

- [ ] Verify all documented CLI flags match `bbox --help` output
- [ ] Verify agent defaults in README match `internal/infra/agent/registry.go`
- [ ] Verify `pkg/infra/` removal doesn't break builds (`task build`)
- [ ] Verify no Go files referenced the removed `pkg/infra/` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)