### PR TITLE
Add agent settings injection into guest VM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ This project follows DDD layered architecture with dependency injection **strict
 - `pkg/domain/workspace/` — WorkspaceCloner interface, Snapshot type
 - `pkg/domain/snapshot/` — FileChange, ExcludeConfig, Matcher, Differ, Reviewer, Flusher
 - `pkg/domain/credential/` — Store, FileStore, Seeder interfaces
+- `pkg/domain/settings/` — Entry, Manifest, FieldFilter, Injector interface for host-to-guest settings injection
 - `pkg/domain/egress/` — DNS-aware egress Policy, Host, ProfileName, Resolve()
 - `pkg/domain/git/` — Identity, IdentityProvider interface
 - `pkg/domain/hostservice/` — Service, Provider for HTTP services exposed to guest
@@ -75,6 +76,7 @@ This project follows DDD layered architecture with dependency injection **strict
 - `internal/infra/diff/` — SHA-256 based file diff engine
 - `internal/infra/review/` — Interactive per-file terminal review, auto-accept reviewer, flusher with hash verification
 - `internal/infra/credential/` — FS-based credential store, Claude credential seeder
+- `internal/infra/settings/` — FSInjector for host-to-guest settings injection (file copy, dir recursion, merge-file with field filtering, JSONC support)
 - `internal/infra/git/` — Host identity provider, `.git/config` credential sanitizer
 - `internal/infra/logging/` — Custom slog file handler
 - `internal/infra/terminal/` — OS terminal wrapper (raw mode, SIGWINCH)

--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -36,6 +36,7 @@ import (
 	inframcp "github.com/stacklok/brood-box/internal/infra/mcp"
 	infraprogress "github.com/stacklok/brood-box/internal/infra/progress"
 	"github.com/stacklok/brood-box/internal/infra/review"
+	infrasettings "github.com/stacklok/brood-box/internal/infra/settings"
 	infrassh "github.com/stacklok/brood-box/internal/infra/ssh"
 	infraterminal "github.com/stacklok/brood-box/internal/infra/terminal"
 	infravm "github.com/stacklok/brood-box/internal/infra/vm"
@@ -86,6 +87,7 @@ func rootCmd() *cobra.Command {
 		noSaveCredentials bool
 		seedCredentials   bool
 		tmpSize           string
+		noSettings        bool
 		noFirmwareDL      bool
 		noImageCache      bool
 		timings           bool
@@ -147,6 +149,7 @@ Example:
 				noGitSSHAgent:     noGitSSHAgent,
 				noSaveCredentials: noSaveCredentials,
 				seedCredentials:   seedCredentials,
+				noSettings:        noSettings,
 				noFirmwareDL:      noFirmwareDL,
 				noImageCache:      noImageCache,
 				timings:           timings,
@@ -180,6 +183,7 @@ Example:
 	cmd.Flags().BoolVar(&noGitSSHAgent, "no-git-ssh-agent", false, "Disable SSH agent forwarding into the VM")
 	cmd.Flags().BoolVar(&noSaveCredentials, "no-save-credentials", false, "Disable saving agent credentials between sessions (enabled by default)")
 	cmd.Flags().BoolVar(&seedCredentials, "seed-credentials", false, "Seed agent credentials from host (e.g. macOS Keychain) into the VM")
+	cmd.Flags().BoolVar(&noSettings, "no-settings", false, "Disable injecting host agent settings (rules, skills, etc.) into the VM")
 	cmd.Flags().BoolVar(&noFirmwareDL, "no-firmware-download", false, "Disable firmware download (use system libkrunfw only)")
 	cmd.Flags().BoolVar(&noImageCache, "no-image-cache", false, "Disable OCI image caching (fresh pull every run)")
 	cmd.Flags().BoolVar(&timings, "timings", false, "Print per-phase timing summary after run")
@@ -294,6 +298,7 @@ type runFlags struct {
 	noGitSSHAgent     bool
 	noSaveCredentials bool
 	seedCredentials   bool
+	noSettings        bool
 	noFirmwareDL      bool
 	noImageCache      bool
 	timings           bool
@@ -470,6 +475,7 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		AgentOverrides:   cfg.Agents,
 		ExtraEgressHosts: configEgressHosts,
 		MCP:              cfg.MCP,
+		SettingsImport:   cfg.SettingsImport,
 	}
 
 	firmwareDownloadEnabled := true
@@ -572,6 +578,17 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 
 	if credentialStore != nil {
 		vmRunnerOpts = append(vmRunnerOpts, infravm.WithCredentialStore(credentialStore))
+	}
+
+	// Wire settings injector (enabled by default, --no-settings to disable).
+	settingsEnabled := cfg.SettingsImport.IsEnabled() && !flags.noSettings
+	if settingsEnabled {
+		settingsInjector := infrasettings.NewFSInjector(logger)
+		vmRunnerOpts = append(vmRunnerOpts, infravm.WithSettingsInjector(settingsInjector))
+	} else if flags.noSettings {
+		// Ensure sandbox config reflects disabled state for the application layer.
+		disabled := false
+		sandboxCfg.SettingsImport.Enabled = &disabled
 	}
 
 	// Wire dependencies.
@@ -963,6 +980,18 @@ func warnLocalConfigOverrides(w io.Writer, localCfg, globalCfg *domainconfig.Con
 		} else {
 			warnings = append(warnings, fmt.Sprintf("sets firmware download: %t", *localCfg.Runtime.FirmwareDownload))
 		}
+	}
+
+	// SettingsImport — local can only disable (tighten).
+	if localCfg.SettingsImport.Enabled != nil {
+		if *localCfg.SettingsImport.Enabled {
+			warnings = append(warnings, "settings_import.enabled=true is ignored — local config can only disable settings import")
+		} else {
+			warnings = append(warnings, "disables agent settings import (rules, skills, etc.)")
+		}
+	}
+	if localCfg.SettingsImport.Categories != nil {
+		warnings = append(warnings, "modifies settings import categories (can only disable)")
 	}
 
 	// MCP authz profile — local can only tighten (tighten-only merge).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,6 +18,7 @@ cmd/bbox-init/main.go        (guest PID 1 init binary)
 pkg/domain/agent/   pkg/domain/config/  pkg/domain/vm/   pkg/domain/session/
 pkg/domain/snapshot/ pkg/domain/workspace/ pkg/domain/egress/
 pkg/domain/git/     pkg/domain/hostservice/ pkg/domain/progress/
+pkg/domain/settings/
    (pure domain — no imports from infra, public SDK)
    │
    │    ┌────────────────┬────────────────┬──────────────┐
@@ -26,9 +27,10 @@ infra/vm/         infra/ssh/        infra/config/   infra/agent/
 (go-microvm)      (PTY terminal)    (YAML loader)   (built-in registry)
 infra/exclude/    infra/workspace/  infra/diff/     infra/review/
 (pattern match)   (COW cloning)     (SHA-256 diff)  (reviewer+flusher)
-infra/git/        infra/mcp/        infra/terminal/ infra/progress/
-(identity+sanitize)(MCP proxy)      (OS terminal)   (spinner+log)
-infra/logging/
+infra/credential/ infra/settings/   infra/terminal/ infra/progress/
+(cred store)      (settings inject) (OS terminal)   (spinner+log)
+infra/git/        infra/mcp/        infra/logging/
+(identity+sanitize)(MCP proxy)
 (slog file handler)
 
 guest/boot/  guest/mount/  guest/network/  guest/env/  guest/sshd/  guest/reaper/
@@ -60,6 +62,10 @@ defines the core types and interfaces.
   `Differ`, `Reviewer`, `Flusher`.
 - **`snapshot/exclude.go`** -- `ExcludeConfig` with security patterns
   (non-overridable) and performance patterns (overridable).
+- **`settings/settings.go`** -- `Entry`, `Manifest`, `FieldFilter`,
+  `EntryKind`, `Injector` interface. Declares what host settings to
+  inject into the guest VM per agent (rules, skills, config files).
+  `FilterEntries()` filters by category predicate.
 - **`egress/egress.go`** -- DNS-aware egress firewall policies.
   `ProfileName` (`permissive`, `standard`, `locked`), `Host` (name,
   ports, protocol), `Policy` (allowed hosts). `Resolve()` maps a
@@ -139,6 +145,11 @@ Concrete implementations of domain interfaces and system integration.
   MCP proxy as an HTTP host service. Includes Cedar-based authorization
   profile resolver (`profiles.go`) with built-in profiles (`observe`,
   `safe-tools`) and support for custom Cedar policies from vmcp config.
+- **`settings/`** -- `FSInjector` implements `settings.Injector`.
+  Copies files, recursively copies directories, and merge-filters
+  config files (JSON/TOML/JSONC) from the host into the guest rootfs.
+  Enforces safety limits (file size, count, depth) and uses O_NOFOLLOW
+  to prevent symlink TOCTOU attacks.
 - **`terminal/`** -- `OSTerminal` wraps real terminal I/O with raw
   mode, SIGWINCH, and dimension queries.
 - **`progress/`** -- `SpinnerObserver` (animated spinner for
@@ -222,8 +233,10 @@ bbox claude-code
         │
         ▼
    Run rootfs hooks:
-     1. InjectInitBinary → /bbox-init (compiled Go binary)
-     2. InjectMCPConfig  → agent-specific MCP config (if MCP enabled)
+     1. InjectInitBinary    → /bbox-init (compiled Go binary)
+     2. InjectCredentials   → saved agent credentials (if any)
+     3. InjectSettings      → host agent settings (rules, skills, config)
+     4. InjectMCPConfig     → agent-specific MCP config (deep-merges)
    go-microvm options inject:
      - SSH keys          → /home/sandbox/.ssh/authorized_keys
      - Env file          → /etc/sandbox-env
@@ -325,6 +338,12 @@ Inside the VM:
 - **VM stopped before review**: The VM is explicitly stopped before
   diff/review/flush, preventing the agent from modifying files during
   the review phase.
+- **Settings injection filtering**: Host agent config files are
+  filtered through allowlists (only listed keys are copied) and
+  deny-subkey patterns (secrets like API keys, tokens, and env vars
+  are stripped from MCP server configs). O_NOFOLLOW prevents symlink
+  TOCTOU attacks during host reads. Source and destination paths are
+  validated with `filepath.EvalSymlinks` containment checks.
 - **MCP authorization profiles**: Opt-in Cedar-based authorization
   restricts what MCP operations the agent can perform. Profiles follow
   tighten-only merge semantics (workspace config can only restrict, not

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -75,6 +75,7 @@ bbox <agent-name> [flags] [-- <agent-args...>]
 | `--mcp-authz-profile` | `full-access` | MCP authorization profile: `full-access`, `observe`, `safe-tools`, `custom` |
 | `--no-git-token` | `false` | Disable forwarding GITHUB_TOKEN/GH_TOKEN into the VM |
 | `--no-git-ssh-agent` | `false` | Disable SSH agent forwarding into the VM |
+| `--no-settings` | `false` | Disable injecting host agent settings (rules, skills, etc.) into the VM |
 | `--no-save-credentials` | `false` | Disable saving agent credentials between sessions |
 | `--seed-credentials` | `false` | Seed agent credentials from host (e.g. macOS Keychain) into the VM |
 | `--no-firmware-download` | `false` | Disable firmware download (use system libkrunfw only) |
@@ -509,6 +510,71 @@ bbox claude-code --no-git-ssh-agent
 
 When snapshot isolation is enabled, the `.git/config` is sanitized to
 remove sensitive values (credentials, tokens) before copying.
+
+## Agent Settings Injection
+
+By default, Brood Box copies your host agent settings (rules, skills,
+commands, instructions, and config files) into the guest VM so the coding
+agent starts with your customizations. Each agent has a declarative manifest
+of what gets injected.
+
+### What Gets Injected
+
+**Claude Code** (`~/.claude/`):
+- `settings.json` — Global settings (filtered: permissions, hooks, model only)
+- `.claude.json` — User MCP servers (secrets stripped)
+- `CLAUDE.md` — Global instructions
+- `rules/`, `agents/`, `skills/`, `commands/` — Directories copied recursively
+
+**Codex** (`~/.codex/`):
+- `config.toml` — Settings (filtered: `[auth]` section excluded)
+- `AGENTS.md`, `AGENTS.override.md` — Instructions
+- `~/.agents/skills/`, `prompts/` — Skills and commands
+
+**OpenCode** (`~/.config/opencode/`):
+- `opencode.json` — Settings (JSONC; provider API keys stripped)
+- `tui.json` — TUI config
+- `AGENTS.md` — Instructions (+ Claude Code `CLAUDE.md` as fallback)
+- `agents/`, `skills/`, `commands/`, `tools/`, `plugins/`, `themes/` — Directories
+
+### Security
+
+- **Allowlist filtering**: Only explicitly listed config keys are copied.
+  New unknown keys in agent config updates are safely ignored.
+- **Secret stripping**: MCP server definitions have `env`, `headers`, `token`,
+  etc. stripped. OpenCode provider configs have API keys stripped.
+- **Size limits**: 1 MiB per file, 50 MiB aggregate, 500 files max, 8 levels depth.
+- **Symlink rejection**: Symlinks are never followed during injection.
+
+### Disabling Settings Injection
+
+```bash
+# Disable all settings injection
+bbox claude-code --no-settings
+```
+
+Or in the config file:
+
+```yaml
+# ~/.config/broodbox/config.yaml
+settings_import:
+  enabled: false
+
+# Or disable specific categories:
+settings_import:
+  categories:
+    skills: false    # Disable skills injection only
+
+# Per-agent override:
+agents:
+  claude-code:
+    settings_import:
+      categories:
+        skills: false
+```
+
+Per-workspace `.broodbox.yaml` can only **disable** settings import
+(tighten-only) — it cannot enable injection that was globally disabled.
 
 ## Signals and Cleanup
 

--- a/internal/infra/agent/registry.go
+++ b/internal/infra/agent/registry.go
@@ -78,8 +78,8 @@ func builtinAgents() map[string]domainagent.Agent {
 			SettingsManifest: &settings.Manifest{Entries: []settings.Entry{
 				{Category: "settings", HostPath: ".claude/settings.json", GuestPath: ".claude/settings.json", Kind: settings.KindMergeFile, Optional: true,
 					Format: "json", Filter: &settings.FieldFilter{AllowKeys: []string{
-						"permissions", "hooks", "model", "preferredNotifChannel", "hasCompletedOnboarding",
-						"autoUpdaterStatus", "bypassPermissions", "enableAllProjectMcpServers",
+						"permissions", "model", "preferredNotifChannel", "hasCompletedOnboarding",
+						"autoUpdaterStatus",
 					}}},
 				// NOTE: .claude.json mcpServers are NOT injected. The VM cannot reach
 				// host MCP servers — only the toolhive-proxied sandbox-tools endpoint

--- a/internal/infra/agent/registry.go
+++ b/internal/infra/agent/registry.go
@@ -81,11 +81,9 @@ func builtinAgents() map[string]domainagent.Agent {
 						"permissions", "hooks", "model", "preferredNotifChannel", "hasCompletedOnboarding",
 						"autoUpdaterStatus", "bypassPermissions", "enableAllProjectMcpServers",
 					}}},
-				{Category: "settings", HostPath: ".claude.json", GuestPath: ".claude.json", Kind: settings.KindMergeFile, Optional: true,
-					Format: "json", Filter: &settings.FieldFilter{
-						AllowKeys:   []string{"mcpServers"},
-						DenySubKeys: map[string][]string{"mcpServers": {"*.env", "*.headers", "*.apiKey", "*.token"}},
-					}},
+				// NOTE: .claude.json mcpServers are NOT injected. The VM cannot reach
+				// host MCP servers — only the toolhive-proxied sandbox-tools endpoint
+				// (injected by the MCP config hook) should be present.
 				{Category: "instructions", HostPath: ".claude/CLAUDE.md", GuestPath: ".claude/CLAUDE.md", Kind: settings.KindFile, Optional: true},
 				{Category: "rules", HostPath: ".claude/rules", GuestPath: ".claude/rules", Kind: settings.KindDirectory, Optional: true},
 				{Category: "agents", HostPath: ".claude/agents", GuestPath: ".claude/agents", Kind: settings.KindDirectory, Optional: true},
@@ -108,15 +106,15 @@ func builtinAgents() map[string]domainagent.Agent {
 				egress.ProfileLocked:   codexLockedHosts,
 				egress.ProfileStandard: append(codexLockedHosts, devInfraHosts...),
 			},
+			// NOTE: mcp_servers is excluded from AllowKeys — the VM cannot reach host
+			// MCP servers. Only the toolhive-proxied sandbox-tools (injected by the
+			// MCP config hook) should be present in the guest config.
 			SettingsManifest: &settings.Manifest{Entries: []settings.Entry{
 				{Category: "settings", HostPath: ".codex/config.toml", GuestPath: ".codex/config.toml", Kind: settings.KindMergeFile, Optional: true,
-					Format: "toml", Filter: &settings.FieldFilter{
-						AllowKeys: []string{
-							"model", "provider", "approval_mode", "features", "mcp_servers", "profiles", "tui",
-							"disable_response_storage", "full_auto_error_mode",
-						},
-						DenySubKeys: map[string][]string{"mcp_servers": {"*.env", "*.headers", "*.apiKey", "*.token"}},
-					}},
+					Format: "toml", Filter: &settings.FieldFilter{AllowKeys: []string{
+						"model", "provider", "approval_mode", "features", "profiles", "tui",
+						"disable_response_storage", "full_auto_error_mode",
+					}}},
 				{Category: "instructions", HostPath: ".codex/AGENTS.md", GuestPath: ".codex/AGENTS.md", Kind: settings.KindFile, Optional: true},
 				{Category: "instructions", HostPath: ".codex/AGENTS.override.md", GuestPath: ".codex/AGENTS.override.md", Kind: settings.KindFile, Optional: true},
 				{Category: "skills", HostPath: ".agents/skills", GuestPath: ".agents/skills", Kind: settings.KindDirectory, Optional: true},
@@ -141,7 +139,9 @@ func builtinAgents() map[string]domainagent.Agent {
 			SettingsManifest: &settings.Manifest{Entries: []settings.Entry{
 				{Category: "settings", HostPath: ".config/opencode/opencode.json", GuestPath: ".config/opencode/opencode.json", Kind: settings.KindMergeFile, Optional: true,
 					Format: "jsonc", Filter: &settings.FieldFilter{
-						AllowKeys: []string{"providers", "models", "mcp", "agent", "tools", "plugin", "theme", "command", "instructions", "formatter", "shell", "permission"},
+						// NOTE: "mcp" is excluded — the VM cannot reach host MCP servers.
+						// Only the toolhive-proxied sandbox-tools should be present.
+						AllowKeys: []string{"providers", "models", "agent", "tools", "plugin", "theme", "command", "instructions", "formatter", "shell", "permission"},
 						DenySubKeys: map[string][]string{"providers": {
 							"*.api_key", "*.apiKey", "*.secret", "*.token",
 							"*.password", "*.credentials", "*.accessToken",

--- a/internal/infra/agent/registry.go
+++ b/internal/infra/agent/registry.go
@@ -10,6 +10,7 @@ import (
 
 	domainagent "github.com/stacklok/brood-box/pkg/domain/agent"
 	"github.com/stacklok/brood-box/pkg/domain/egress"
+	"github.com/stacklok/brood-box/pkg/domain/settings"
 )
 
 // Common dev infrastructure hosts shared across agents at the standard profile.
@@ -74,6 +75,23 @@ func builtinAgents() map[string]domainagent.Agent {
 				egress.ProfileLocked:   claudeLockedHosts,
 				egress.ProfileStandard: append(claudeLockedHosts, devInfraHosts...),
 			},
+			SettingsManifest: &settings.Manifest{Entries: []settings.Entry{
+				{Category: "settings", HostPath: ".claude/settings.json", GuestPath: ".claude/settings.json", Kind: settings.KindMergeFile, Optional: true,
+					Format: "json", Filter: &settings.FieldFilter{AllowKeys: []string{
+						"permissions", "hooks", "model", "preferredNotifChannel", "hasCompletedOnboarding",
+						"autoUpdaterStatus", "bypassPermissions", "enableAllProjectMcpServers",
+					}}},
+				{Category: "settings", HostPath: ".claude.json", GuestPath: ".claude.json", Kind: settings.KindMergeFile, Optional: true,
+					Format: "json", Filter: &settings.FieldFilter{
+						AllowKeys:   []string{"mcpServers"},
+						DenySubKeys: map[string][]string{"mcpServers": {"*.env", "*.headers", "*.apiKey", "*.token"}},
+					}},
+				{Category: "instructions", HostPath: ".claude/CLAUDE.md", GuestPath: ".claude/CLAUDE.md", Kind: settings.KindFile, Optional: true},
+				{Category: "rules", HostPath: ".claude/rules", GuestPath: ".claude/rules", Kind: settings.KindDirectory, Optional: true},
+				{Category: "agents", HostPath: ".claude/agents", GuestPath: ".claude/agents", Kind: settings.KindDirectory, Optional: true},
+				{Category: "skills", HostPath: ".claude/skills", GuestPath: ".claude/skills", Kind: settings.KindDirectory, Optional: true},
+				{Category: "commands", HostPath: ".claude/commands", GuestPath: ".claude/commands", Kind: settings.KindDirectory, Optional: true},
+			}},
 		},
 		"codex": {
 			Name:                 "codex",
@@ -90,6 +108,20 @@ func builtinAgents() map[string]domainagent.Agent {
 				egress.ProfileLocked:   codexLockedHosts,
 				egress.ProfileStandard: append(codexLockedHosts, devInfraHosts...),
 			},
+			SettingsManifest: &settings.Manifest{Entries: []settings.Entry{
+				{Category: "settings", HostPath: ".codex/config.toml", GuestPath: ".codex/config.toml", Kind: settings.KindMergeFile, Optional: true,
+					Format: "toml", Filter: &settings.FieldFilter{
+						AllowKeys: []string{
+							"model", "provider", "approval_mode", "features", "mcp_servers", "profiles", "tui",
+							"disable_response_storage", "full_auto_error_mode",
+						},
+						DenySubKeys: map[string][]string{"mcp_servers": {"*.env", "*.headers", "*.apiKey", "*.token"}},
+					}},
+				{Category: "instructions", HostPath: ".codex/AGENTS.md", GuestPath: ".codex/AGENTS.md", Kind: settings.KindFile, Optional: true},
+				{Category: "instructions", HostPath: ".codex/AGENTS.override.md", GuestPath: ".codex/AGENTS.override.md", Kind: settings.KindFile, Optional: true},
+				{Category: "skills", HostPath: ".agents/skills", GuestPath: ".agents/skills", Kind: settings.KindDirectory, Optional: true},
+				{Category: "commands", HostPath: ".codex/prompts", GuestPath: ".codex/prompts", Kind: settings.KindDirectory, Optional: true},
+			}},
 		},
 		"opencode": {
 			Name:                 "opencode",
@@ -106,6 +138,28 @@ func builtinAgents() map[string]domainagent.Agent {
 				egress.ProfileLocked:   opencodeLockedHosts,
 				egress.ProfileStandard: append(opencodeLockedHosts, devInfraHosts...),
 			},
+			SettingsManifest: &settings.Manifest{Entries: []settings.Entry{
+				{Category: "settings", HostPath: ".config/opencode/opencode.json", GuestPath: ".config/opencode/opencode.json", Kind: settings.KindMergeFile, Optional: true,
+					Format: "jsonc", Filter: &settings.FieldFilter{
+						AllowKeys: []string{"providers", "models", "mcp", "agent", "tools", "plugin", "theme", "command", "instructions", "formatter", "shell", "permission"},
+						DenySubKeys: map[string][]string{"providers": {
+							"*.api_key", "*.apiKey", "*.secret", "*.token",
+							"*.password", "*.credentials", "*.accessToken",
+							"*.access_token", "*.client_secret",
+						}},
+					}},
+				{Category: "settings", HostPath: ".config/opencode/tui.json", GuestPath: ".config/opencode/tui.json", Kind: settings.KindFile, Optional: true},
+				{Category: "instructions", HostPath: ".config/opencode/AGENTS.md", GuestPath: ".config/opencode/AGENTS.md", Kind: settings.KindFile, Optional: true},
+				{Category: "instructions", HostPath: ".claude/CLAUDE.md", GuestPath: ".claude/CLAUDE.md", Kind: settings.KindFile, Optional: true},
+				{Category: "agents", HostPath: ".config/opencode/agents", GuestPath: ".config/opencode/agents", Kind: settings.KindDirectory, Optional: true},
+				{Category: "skills", HostPath: ".config/opencode/skills", GuestPath: ".config/opencode/skills", Kind: settings.KindDirectory, Optional: true},
+				{Category: "skills", HostPath: ".claude/skills", GuestPath: ".claude/skills", Kind: settings.KindDirectory, Optional: true},
+				{Category: "skills", HostPath: ".agents/skills", GuestPath: ".agents/skills", Kind: settings.KindDirectory, Optional: true},
+				{Category: "commands", HostPath: ".config/opencode/commands", GuestPath: ".config/opencode/commands", Kind: settings.KindDirectory, Optional: true},
+				{Category: "tools", HostPath: ".config/opencode/tools", GuestPath: ".config/opencode/tools", Kind: settings.KindDirectory, Optional: true},
+				{Category: "plugins", HostPath: ".config/opencode/plugins", GuestPath: ".config/opencode/plugins", Kind: settings.KindDirectory, Optional: true},
+				{Category: "themes", HostPath: ".config/opencode/themes", GuestPath: ".config/opencode/themes", Kind: settings.KindDirectory, Optional: true},
+			}},
 		},
 	}
 }

--- a/internal/infra/settings/injector.go
+++ b/internal/infra/settings/injector.go
@@ -146,12 +146,12 @@ func (f *FSInjector) injectFile(
 	if err := os.MkdirAll(filepath.Dir(dstPath), dirPerm); err != nil {
 		return fmt.Errorf("creating parent dirs: %w", err)
 	}
-	bestEffortChown(filepath.Dir(dstPath))
+	bestEffortChown(f.logger, filepath.Dir(dstPath))
 
 	if err := os.WriteFile(dstPath, data, filePerm); err != nil {
 		return fmt.Errorf("writing destination: %w", err)
 	}
-	bestEffortChown(dstPath)
+	bestEffortChown(f.logger, dstPath)
 
 	c.fileCount++
 	c.totalSize += dataSize
@@ -203,7 +203,7 @@ func (f *FSInjector) injectDirectory(
 	if err := os.MkdirAll(dstPath, dirPerm); err != nil {
 		return fmt.Errorf("creating directory: %w", err)
 	}
-	bestEffortChown(dstPath)
+	bestEffortChown(f.logger, dstPath)
 
 	entries, err := os.ReadDir(srcPath)
 	if err != nil {
@@ -333,12 +333,12 @@ func (f *FSInjector) injectMergeFile(
 	if err := os.MkdirAll(filepath.Dir(dstPath), dirPerm); err != nil {
 		return fmt.Errorf("creating parent dirs: %w", err)
 	}
-	bestEffortChown(filepath.Dir(dstPath))
+	bestEffortChown(f.logger, filepath.Dir(dstPath))
 
 	if err := os.WriteFile(dstPath, output, filePerm); err != nil {
 		return fmt.Errorf("writing merged file: %w", err)
 	}
-	bestEffortChown(dstPath)
+	bestEffortChown(f.logger, dstPath)
 
 	c.fileCount++
 	c.totalSize += int64(len(output))
@@ -437,8 +437,8 @@ func applyFilter(data map[string]any, filter *settings.FieldFilter) map[string]a
 	return result
 }
 
-// applyDenySubKeys removes matching sub-keys from the value.
-// Patterns like "*.apiKey" strip "apiKey" from every map entry under the value.
+// applyDenySubKeys removes matching sub-keys from the value, recursing into
+// nested maps so that patterns like "*.apiKey" strip the key at all depths.
 func applyDenySubKeys(val any, patterns []string) any {
 	topMap, ok := val.(map[string]any)
 	if !ok {
@@ -447,16 +447,9 @@ func applyDenySubKeys(val any, patterns []string) any {
 
 	for _, pattern := range patterns {
 		if strings.HasPrefix(pattern, "*.") {
-			// Wildcard: strip the sub-key from every map entry.
 			subKey := strings.TrimPrefix(pattern, "*.")
-			for entryKey, entryVal := range topMap {
-				if innerMap, ok := entryVal.(map[string]any); ok {
-					delete(innerMap, subKey)
-					topMap[entryKey] = innerMap
-				}
-			}
+			stripKeyRecursive(topMap, subKey)
 		} else {
-			// Direct key removal.
 			delete(topMap, pattern)
 		}
 	}
@@ -464,9 +457,24 @@ func applyDenySubKeys(val any, patterns []string) any {
 	return topMap
 }
 
+// stripKeyRecursive removes subKey from m and from every nested map within m.
+func stripKeyRecursive(m map[string]any, subKey string) {
+	delete(m, subKey)
+	for _, v := range m {
+		if nested, ok := v.(map[string]any); ok {
+			stripKeyRecursive(nested, subKey)
+		}
+	}
+}
+
 // deepMerge recursively merges src into dst. Values from src override dst.
 // Both maps are treated as nested map[string]any structures.
+// Recursion is bounded by settings.MaxDepth to prevent stack overflow.
 func deepMerge(dst, src map[string]any) map[string]any {
+	return deepMergeN(dst, src, 0)
+}
+
+func deepMergeN(dst, src map[string]any, depth int) map[string]any {
 	result := make(map[string]any, len(dst))
 	for k, v := range dst {
 		result[k] = v
@@ -482,8 +490,8 @@ func deepMerge(dst, src map[string]any) map[string]any {
 		srcMap, srcIsMap := srcVal.(map[string]any)
 		dstMap, dstIsMap := dstVal.(map[string]any)
 
-		if srcIsMap && dstIsMap {
-			result[k] = deepMerge(dstMap, srcMap)
+		if srcIsMap && dstIsMap && depth < settings.MaxDepth {
+			result[k] = deepMergeN(dstMap, srcMap, depth+1)
 		} else {
 			result[k] = srcVal
 		}
@@ -558,9 +566,9 @@ func readFileNoFollow(path string) ([]byte, error) {
 }
 
 // bestEffortChown attempts to chown a path to the sandbox user, ignoring EPERM.
-func bestEffortChown(path string) {
+func bestEffortChown(logger *slog.Logger, path string) {
 	err := os.Lchown(path, sandboxUID, sandboxGID)
 	if err != nil && !errors.Is(err, syscall.EPERM) && !errors.Is(err, fs.ErrPermission) {
-		slog.Debug("unexpected chown error", "path", path, "error", err)
+		logger.Debug("unexpected chown error", "path", path, "error", err)
 	}
 }

--- a/internal/infra/settings/injector.go
+++ b/internal/infra/settings/injector.go
@@ -1,0 +1,566 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package settings implements host-to-guest settings injection by copying,
+// filtering, and merging configuration files into the guest rootfs.
+package settings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	toml "github.com/pelletier/go-toml/v2"
+
+	"github.com/stacklok/brood-box/pkg/domain/settings"
+)
+
+const (
+	// sandboxHome is the home directory of the sandbox user inside the guest rootfs.
+	sandboxHome = "home/sandbox"
+
+	// sandboxUID is the UID of the sandbox user inside the guest.
+	sandboxUID = 1000
+	// sandboxGID is the GID of the sandbox user inside the guest.
+	sandboxGID = 1000
+
+	dirPerm  = 0700
+	filePerm = 0600
+)
+
+// FSInjector copies filtered settings from the host into the guest rootfs.
+type FSInjector struct {
+	logger *slog.Logger
+}
+
+// NewFSInjector creates a new filesystem-backed settings injector.
+func NewFSInjector(logger *slog.Logger) *FSInjector {
+	return &FSInjector{logger: logger}
+}
+
+// counters tracks aggregate limits across all manifest entries.
+type counters struct {
+	fileCount int
+	totalSize int64
+}
+
+// Inject processes each entry in the manifest, copying files from hostHomeDir
+// into rootfsPath according to each entry's Kind.
+func (f *FSInjector) Inject(rootfsPath, hostHomeDir string, manifest settings.Manifest) error {
+	c := &counters{}
+
+	for _, entry := range manifest.Entries {
+		if err := f.processEntry(rootfsPath, hostHomeDir, entry, c); err != nil {
+			return fmt.Errorf("injecting %q: %w", entry.HostPath, err)
+		}
+	}
+
+	f.logger.Info("settings injection complete",
+		"files", c.fileCount, "total_bytes", c.totalSize)
+	return nil
+}
+
+func (f *FSInjector) processEntry(
+	rootfsPath, hostHomeDir string,
+	entry settings.Entry,
+	c *counters,
+) error {
+	switch entry.Kind {
+	case settings.KindFile:
+		return f.injectFile(rootfsPath, hostHomeDir, entry, c)
+	case settings.KindDirectory:
+		return f.injectDirectory(rootfsPath, hostHomeDir, entry, c, 0)
+	case settings.KindMergeFile:
+		return f.injectMergeFile(rootfsPath, hostHomeDir, entry, c)
+	default:
+		return fmt.Errorf("unknown entry kind: %d", entry.Kind)
+	}
+}
+
+// injectFile copies a single file from host to guest.
+func (f *FSInjector) injectFile(
+	rootfsPath, hostHomeDir string,
+	entry settings.Entry,
+	c *counters,
+) error {
+	srcPath := filepath.Join(hostHomeDir, entry.HostPath)
+
+	// Validate source stays within host home (defense-in-depth).
+	if err := validateContainment(hostHomeDir, srcPath); err != nil {
+		return fmt.Errorf("source path containment: %w", err)
+	}
+
+	info, err := os.Lstat(srcPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && entry.Optional {
+			f.logger.Debug("optional file not found, skipping", "path", entry.HostPath)
+			return nil
+		}
+		return fmt.Errorf("stat source: %w", err)
+	}
+
+	// Skip symlinks.
+	if info.Mode()&os.ModeSymlink != 0 {
+		f.logger.Warn("skipping symlink", "path", srcPath)
+		return nil
+	}
+
+	if info.Size() > settings.MaxFileSize {
+		return fmt.Errorf("file %q exceeds max size (%d > %d)", entry.HostPath, info.Size(), settings.MaxFileSize)
+	}
+
+	if c.fileCount >= settings.MaxFileCount {
+		return fmt.Errorf("file count would exceed limit (%d)", settings.MaxFileCount)
+	}
+
+	dstPath := filepath.Join(rootfsPath, sandboxHome, entry.GuestPath)
+
+	if err := validateContainment(filepath.Join(rootfsPath, sandboxHome), dstPath); err != nil {
+		return fmt.Errorf("path containment: %w", err)
+	}
+
+	// Open with O_NOFOLLOW to prevent TOCTOU symlink attacks between
+	// the Lstat check and the actual file read.
+	data, err := readFileNoFollow(srcPath)
+	if err != nil {
+		return fmt.Errorf("reading source: %w", err)
+	}
+
+	// Use actual read size for aggregate tracking (not stat size) to
+	// prevent TOCTOU between stat and read.
+	dataSize := int64(len(data))
+	if dataSize > settings.MaxFileSize {
+		return fmt.Errorf("file %q read size exceeds max (%d > %d)", entry.HostPath, dataSize, settings.MaxFileSize)
+	}
+	if c.totalSize+dataSize > settings.MaxTotalSize {
+		return fmt.Errorf("aggregate size would exceed limit (%d)", settings.MaxTotalSize)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dstPath), dirPerm); err != nil {
+		return fmt.Errorf("creating parent dirs: %w", err)
+	}
+	bestEffortChown(filepath.Dir(dstPath))
+
+	if err := os.WriteFile(dstPath, data, filePerm); err != nil {
+		return fmt.Errorf("writing destination: %w", err)
+	}
+	bestEffortChown(dstPath)
+
+	c.fileCount++
+	c.totalSize += dataSize
+
+	f.logger.Debug("injected file", "src", entry.HostPath, "dst", entry.GuestPath)
+	return nil
+}
+
+// injectDirectory recursively copies a directory from host to guest.
+func (f *FSInjector) injectDirectory(
+	rootfsPath, hostHomeDir string,
+	entry settings.Entry,
+	c *counters,
+	depth int,
+) error {
+	if depth >= settings.MaxDepth {
+		f.logger.Warn("skipping directory exceeding max depth", "path", entry.HostPath, "depth", depth)
+		return nil
+	}
+
+	srcPath := filepath.Join(hostHomeDir, entry.HostPath)
+
+	// Validate source stays within host home (defense-in-depth).
+	if err := validateContainment(hostHomeDir, srcPath); err != nil {
+		return fmt.Errorf("source path containment: %w", err)
+	}
+
+	info, err := os.Lstat(srcPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && entry.Optional {
+			f.logger.Debug("optional directory not found, skipping", "path", entry.HostPath)
+			return nil
+		}
+		return fmt.Errorf("stat source dir: %w", err)
+	}
+
+	// Skip symlinks.
+	if info.Mode()&os.ModeSymlink != 0 {
+		f.logger.Warn("skipping symlink directory", "path", srcPath)
+		return nil
+	}
+
+	dstPath := filepath.Join(rootfsPath, sandboxHome, entry.GuestPath)
+
+	if err := validateContainment(filepath.Join(rootfsPath, sandboxHome), dstPath); err != nil {
+		return fmt.Errorf("path containment: %w", err)
+	}
+
+	if err := os.MkdirAll(dstPath, dirPerm); err != nil {
+		return fmt.Errorf("creating directory: %w", err)
+	}
+	bestEffortChown(dstPath)
+
+	entries, err := os.ReadDir(srcPath)
+	if err != nil {
+		return fmt.Errorf("reading directory: %w", err)
+	}
+
+	for _, de := range entries {
+		childHostPath := filepath.Join(entry.HostPath, de.Name())
+		childGuestPath := filepath.Join(entry.GuestPath, de.Name())
+
+		childEntry := settings.Entry{
+			HostPath:  childHostPath,
+			GuestPath: childGuestPath,
+			Optional:  entry.Optional,
+		}
+
+		childInfo, err := os.Lstat(filepath.Join(hostHomeDir, childHostPath))
+		if err != nil {
+			return fmt.Errorf("lstat %q: %w", childHostPath, err)
+		}
+
+		// Skip symlinks.
+		if childInfo.Mode()&os.ModeSymlink != 0 {
+			f.logger.Warn("skipping symlink", "path", childHostPath)
+			continue
+		}
+
+		if childInfo.IsDir() {
+			childEntry.Kind = settings.KindDirectory
+			if err := f.injectDirectory(rootfsPath, hostHomeDir, childEntry, c, depth+1); err != nil {
+				return err
+			}
+		} else {
+			childEntry.Kind = settings.KindFile
+			if err := f.injectFile(rootfsPath, hostHomeDir, childEntry, c); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// injectMergeFile reads a host config file, filters it, and deep-merges
+// the result into an existing guest file.
+func (f *FSInjector) injectMergeFile(
+	rootfsPath, hostHomeDir string,
+	entry settings.Entry,
+	c *counters,
+) error {
+	srcPath := filepath.Join(hostHomeDir, entry.HostPath)
+
+	// Validate source stays within host home (defense-in-depth).
+	if err := validateContainment(hostHomeDir, srcPath); err != nil {
+		return fmt.Errorf("source path containment: %w", err)
+	}
+
+	info, err := os.Lstat(srcPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && entry.Optional {
+			f.logger.Debug("optional merge file not found, skipping", "path", entry.HostPath)
+			return nil
+		}
+		return fmt.Errorf("stat source: %w", err)
+	}
+
+	// Skip symlinks.
+	if info.Mode()&os.ModeSymlink != 0 {
+		f.logger.Warn("skipping symlink", "path", srcPath)
+		return nil
+	}
+
+	if info.Size() > settings.MaxFileSize {
+		return fmt.Errorf("file %q exceeds max size (%d > %d)", entry.HostPath, info.Size(), settings.MaxFileSize)
+	}
+
+	if c.fileCount >= settings.MaxFileCount {
+		return fmt.Errorf("file count would exceed limit (%d)", settings.MaxFileCount)
+	}
+
+	dstPath := filepath.Join(rootfsPath, sandboxHome, entry.GuestPath)
+
+	if err := validateContainment(filepath.Join(rootfsPath, sandboxHome), dstPath); err != nil {
+		return fmt.Errorf("path containment: %w", err)
+	}
+
+	// Open with O_NOFOLLOW to prevent TOCTOU symlink attacks.
+	rawHost, err := readFileNoFollow(srcPath)
+	if err != nil {
+		return fmt.Errorf("reading host file: %w", err)
+	}
+
+	hostData, err := parseConfig(rawHost, entry.Format)
+	if err != nil {
+		return fmt.Errorf("parsing host file %q: %w", entry.HostPath, err)
+	}
+
+	// Apply filters.
+	if entry.Filter != nil {
+		hostData = applyFilter(hostData, entry.Filter)
+	}
+
+	// Read existing guest file (may have been placed by credential injection).
+	var guestData map[string]any
+	rawGuest, err := os.ReadFile(dstPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("reading existing guest file: %w", err)
+		}
+		guestData = make(map[string]any)
+	} else {
+		guestData, err = parseConfig(rawGuest, entry.Format)
+		if err != nil {
+			return fmt.Errorf("parsing existing guest file: %w", err)
+		}
+	}
+
+	// Deep-merge: host data overrides guest data.
+	merged := deepMerge(guestData, hostData)
+
+	// Serialize back.
+	output, err := serializeConfig(merged, entry.Format)
+	if err != nil {
+		return fmt.Errorf("serializing merged config: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dstPath), dirPerm); err != nil {
+		return fmt.Errorf("creating parent dirs: %w", err)
+	}
+	bestEffortChown(filepath.Dir(dstPath))
+
+	if err := os.WriteFile(dstPath, output, filePerm); err != nil {
+		return fmt.Errorf("writing merged file: %w", err)
+	}
+	bestEffortChown(dstPath)
+
+	c.fileCount++
+	c.totalSize += int64(len(output))
+
+	f.logger.Debug("injected merge file", "src", entry.HostPath, "dst", entry.GuestPath)
+	return nil
+}
+
+// parseConfig parses data according to format into a generic map.
+func parseConfig(data []byte, format string) (map[string]any, error) {
+	switch format {
+	case "json":
+		return parseJSON(data)
+	case "jsonc":
+		stripped := stripJSONC(data)
+		return parseJSON(stripped)
+	case "toml":
+		return parseTOML(data)
+	default:
+		return nil, fmt.Errorf("unsupported format: %q", format)
+	}
+}
+
+func parseJSON(data []byte) (map[string]any, error) {
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing JSON: %w", err)
+	}
+	return m, nil
+}
+
+func parseTOML(data []byte) (map[string]any, error) {
+	var m map[string]any
+	if err := toml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing TOML: %w", err)
+	}
+	return m, nil
+}
+
+// serializeConfig writes data back in the given format.
+func serializeConfig(data map[string]any, format string) ([]byte, error) {
+	switch format {
+	case "json", "jsonc":
+		out, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("marshaling JSON: %w", err)
+		}
+		// Append trailing newline for consistency.
+		return append(out, '\n'), nil
+	case "toml":
+		out, err := toml.Marshal(data)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling TOML: %w", err)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported format: %q", format)
+	}
+}
+
+// applyFilter keeps only allowed top-level keys and strips denied sub-keys.
+func applyFilter(data map[string]any, filter *settings.FieldFilter) map[string]any {
+	if len(filter.AllowKeys) == 0 && len(filter.DenySubKeys) == 0 {
+		return data
+	}
+
+	result := make(map[string]any)
+
+	// If AllowKeys is set, keep only those top-level keys.
+	if len(filter.AllowKeys) > 0 {
+		allowed := make(map[string]bool, len(filter.AllowKeys))
+		for _, k := range filter.AllowKeys {
+			allowed[k] = true
+		}
+		for k, v := range data {
+			if allowed[k] {
+				result[k] = v
+			}
+		}
+	} else {
+		// Copy all keys.
+		for k, v := range data {
+			result[k] = v
+		}
+	}
+
+	// Apply deny sub-key patterns.
+	for topKey, patterns := range filter.DenySubKeys {
+		val, ok := result[topKey]
+		if !ok {
+			continue
+		}
+		result[topKey] = applyDenySubKeys(val, patterns)
+	}
+
+	return result
+}
+
+// applyDenySubKeys removes matching sub-keys from the value.
+// Patterns like "*.apiKey" strip "apiKey" from every map entry under the value.
+func applyDenySubKeys(val any, patterns []string) any {
+	topMap, ok := val.(map[string]any)
+	if !ok {
+		return val
+	}
+
+	for _, pattern := range patterns {
+		if strings.HasPrefix(pattern, "*.") {
+			// Wildcard: strip the sub-key from every map entry.
+			subKey := strings.TrimPrefix(pattern, "*.")
+			for entryKey, entryVal := range topMap {
+				if innerMap, ok := entryVal.(map[string]any); ok {
+					delete(innerMap, subKey)
+					topMap[entryKey] = innerMap
+				}
+			}
+		} else {
+			// Direct key removal.
+			delete(topMap, pattern)
+		}
+	}
+
+	return topMap
+}
+
+// deepMerge recursively merges src into dst. Values from src override dst.
+// Both maps are treated as nested map[string]any structures.
+func deepMerge(dst, src map[string]any) map[string]any {
+	result := make(map[string]any, len(dst))
+	for k, v := range dst {
+		result[k] = v
+	}
+
+	for k, srcVal := range src {
+		dstVal, exists := result[k]
+		if !exists {
+			result[k] = srcVal
+			continue
+		}
+
+		srcMap, srcIsMap := srcVal.(map[string]any)
+		dstMap, dstIsMap := dstVal.(map[string]any)
+
+		if srcIsMap && dstIsMap {
+			result[k] = deepMerge(dstMap, srcMap)
+		} else {
+			result[k] = srcVal
+		}
+	}
+
+	return result
+}
+
+// validateContainment ensures target stays under base directory.
+// Used for both source (host home) and destination (rootfs) paths.
+func validateContainment(base, target string) error {
+	cleaned := filepath.Clean(target)
+
+	rel, err := filepath.Rel(base, cleaned)
+	if err != nil {
+		return fmt.Errorf("computing relative path: %w", err)
+	}
+
+	if strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("path %q escapes base %q", target, base)
+	}
+
+	// Resolve symlinks where possible to prevent symlinked intermediate
+	// directories from escaping containment.
+	resolvedTarget, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Target doesn't exist yet — resolve parent instead.
+			resolvedDir, dirErr := filepath.EvalSymlinks(filepath.Dir(cleaned))
+			if dirErr != nil {
+				if errors.Is(dirErr, os.ErrNotExist) {
+					return nil // parent doesn't exist either; safe
+				}
+				return fmt.Errorf("resolving parent symlinks: %w", dirErr)
+			}
+			resolvedTarget = filepath.Join(resolvedDir, filepath.Base(cleaned))
+		} else {
+			return fmt.Errorf("resolving target symlinks: %w", err)
+		}
+	}
+
+	resolvedBase, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("resolving base symlinks: %w", err)
+	}
+
+	if !strings.HasPrefix(resolvedTarget+"/", resolvedBase+"/") {
+		return fmt.Errorf("resolved path %q escapes base %q", resolvedTarget, resolvedBase)
+	}
+
+	return nil
+}
+
+// readFileNoFollow opens a file with O_NOFOLLOW to prevent TOCTOU symlink
+// attacks between the Lstat check and the actual read.
+func readFileNoFollow(path string) ([]byte, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open (O_NOFOLLOW): %w", err)
+	}
+	f := os.NewFile(uintptr(fd), path)
+	defer func() { _ = f.Close() }()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+	return data, nil
+}
+
+// bestEffortChown attempts to chown a path to the sandbox user, ignoring EPERM.
+func bestEffortChown(path string) {
+	err := os.Lchown(path, sandboxUID, sandboxGID)
+	if err != nil && !errors.Is(err, syscall.EPERM) && !errors.Is(err, fs.ErrPermission) {
+		slog.Debug("unexpected chown error", "path", path, "error", err)
+	}
+}

--- a/internal/infra/settings/injector_test.go
+++ b/internal/infra/settings/injector_test.go
@@ -639,3 +639,528 @@ func TestFSInjector_MergeFileJSONC(t *testing.T) {
 	_, hasAPIKey := result["apiKey"]
 	assert.False(t, hasAPIKey)
 }
+
+func TestStripKeyRecursive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  map[string]any
+		subKey string
+		want   map[string]any
+	}{
+		{
+			name:   "strips key at top level",
+			input:  map[string]any{"apiKey": "secret", "theme": "dark"},
+			subKey: "apiKey",
+			want:   map[string]any{"theme": "dark"},
+		},
+		{
+			name: "strips key at nested level",
+			input: map[string]any{
+				"github": map[string]any{
+					"url":    "https://github.com",
+					"apiKey": "ghp_secret",
+				},
+				"theme": "dark",
+			},
+			subKey: "apiKey",
+			want: map[string]any{
+				"github": map[string]any{
+					"url": "https://github.com",
+				},
+				"theme": "dark",
+			},
+		},
+		{
+			name: "strips key at three levels deep",
+			input: map[string]any{
+				"level1": map[string]any{
+					"level2": map[string]any{
+						"level3": map[string]any{
+							"apiKey": "deep-secret",
+							"safe":   "keep",
+						},
+						"apiKey": "mid-secret",
+					},
+					"apiKey": "shallow-secret",
+				},
+			},
+			subKey: "apiKey",
+			want: map[string]any{
+				"level1": map[string]any{
+					"level2": map[string]any{
+						"level3": map[string]any{
+							"safe": "keep",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "handles mixed nesting (maps and scalars)",
+			input: map[string]any{
+				"apiKey": "top-secret",
+				"count":  42,
+				"nested": map[string]any{
+					"apiKey": "nested-secret",
+					"list":   []string{"a", "b"},
+				},
+				"flat": "value",
+			},
+			subKey: "apiKey",
+			want: map[string]any{
+				"count": 42,
+				"nested": map[string]any{
+					"list": []string{"a", "b"},
+				},
+				"flat": "value",
+			},
+		},
+		{
+			name:   "no-op when key does not exist",
+			input:  map[string]any{"theme": "dark", "editor": "vim"},
+			subKey: "apiKey",
+			want:   map[string]any{"theme": "dark", "editor": "vim"},
+		},
+		{
+			name:   "empty map is a no-op",
+			input:  map[string]any{},
+			subKey: "apiKey",
+			want:   map[string]any{},
+		},
+		{
+			name: "strips key only from maps, not scalar siblings",
+			input: map[string]any{
+				"providers": map[string]any{
+					"gh": map[string]any{
+						"apiKey": "ghp_123",
+						"url":    "https://github.com",
+					},
+					"gl": map[string]any{
+						"apiKey": "glpat_456",
+						"url":    "https://gitlab.com",
+					},
+				},
+				"other": "scalar-value",
+			},
+			subKey: "apiKey",
+			want: map[string]any{
+				"providers": map[string]any{
+					"gh": map[string]any{
+						"url": "https://github.com",
+					},
+					"gl": map[string]any{
+						"url": "https://gitlab.com",
+					},
+				},
+				"other": "scalar-value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stripKeyRecursive(tt.input, tt.subKey)
+			assert.Equal(t, tt.want, tt.input)
+		})
+	}
+}
+
+func TestDeepMerge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		dst  map[string]any
+		src  map[string]any
+		want map[string]any
+	}{
+		{
+			name: "disjoint keys are combined",
+			dst:  map[string]any{"a": 1},
+			src:  map[string]any{"b": 2},
+			want: map[string]any{"a": 1, "b": 2},
+		},
+		{
+			name: "overlapping scalar keys — src wins",
+			dst:  map[string]any{"key": "old"},
+			src:  map[string]any{"key": "new"},
+			want: map[string]any{"key": "new"},
+		},
+		{
+			name: "nested map merge is recursive",
+			dst: map[string]any{
+				"outer": map[string]any{
+					"a": 1,
+					"b": 2,
+				},
+			},
+			src: map[string]any{
+				"outer": map[string]any{
+					"b": 99,
+					"c": 3,
+				},
+			},
+			want: map[string]any{
+				"outer": map[string]any{
+					"a": 1,
+					"b": 99,
+					"c": 3,
+				},
+			},
+		},
+		{
+			name: "src has map, dst has scalar for same key — src wins",
+			dst:  map[string]any{"key": "scalar"},
+			src:  map[string]any{"key": map[string]any{"nested": true}},
+			want: map[string]any{"key": map[string]any{"nested": true}},
+		},
+		{
+			name: "dst has map, src has scalar for same key — src wins",
+			dst:  map[string]any{"key": map[string]any{"nested": true}},
+			src:  map[string]any{"key": "scalar"},
+			want: map[string]any{"key": "scalar"},
+		},
+		{
+			name: "empty src leaves dst unchanged",
+			dst:  map[string]any{"a": 1, "b": 2},
+			src:  map[string]any{},
+			want: map[string]any{"a": 1, "b": 2},
+		},
+		{
+			name: "empty dst returns src",
+			dst:  map[string]any{},
+			src:  map[string]any{"a": 1},
+			want: map[string]any{"a": 1},
+		},
+		{
+			name: "both empty returns empty",
+			dst:  map[string]any{},
+			src:  map[string]any{},
+			want: map[string]any{},
+		},
+		{
+			name: "nil values in maps are preserved",
+			dst:  map[string]any{"a": nil},
+			src:  map[string]any{"b": nil},
+			want: map[string]any{"a": nil, "b": nil},
+		},
+		{
+			name: "src nil value overwrites dst scalar",
+			dst:  map[string]any{"key": "value"},
+			src:  map[string]any{"key": nil},
+			want: map[string]any{"key": nil},
+		},
+		{
+			name: "does not mutate original dst",
+			dst:  map[string]any{"a": 1},
+			src:  map[string]any{"b": 2},
+			want: map[string]any{"a": 1, "b": 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := deepMerge(tt.dst, tt.src)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	// Verify deepMerge does not mutate the original dst map.
+	t.Run("original dst is not mutated", func(t *testing.T) {
+		t.Parallel()
+
+		dst := map[string]any{"a": 1}
+		src := map[string]any{"b": 2}
+		result := deepMerge(dst, src)
+
+		// result has both keys
+		assert.Equal(t, map[string]any{"a": 1, "b": 2}, result)
+		// original dst should be unmodified
+		_, hasBInDst := dst["b"]
+		assert.False(t, hasBInDst, "original dst should not contain key 'b'")
+	})
+}
+
+func TestDeepMergeN(t *testing.T) {
+	t.Parallel()
+
+	t.Run("respects MaxDepth — replaces wholesale at depth limit", func(t *testing.T) {
+		t.Parallel()
+
+		// The check in deepMergeN is: if depth < MaxDepth, recurse; else replace.
+		// At depth d, processing a key whose src and dst are both maps:
+		//   - d < MaxDepth  -> recurse into depth d+1
+		//   - d >= MaxDepth -> src map replaces dst map wholesale
+		//
+		// We need MaxDepth+1 layers of map nesting so that the innermost
+		// pair of leaf maps is encountered at depth == MaxDepth, where
+		// the wholesale-replace path fires.
+		dstLeaf := map[string]any{"dstOnly": "kept-by-dst", "shared": "dst-val"}
+		srcLeaf := map[string]any{"srcOnly": "from-src", "shared": "src-val"}
+
+		// Wrap in MaxDepth+1 layers so the leaf maps sit at depth MaxDepth.
+		var dst, src any = dstLeaf, srcLeaf
+		for i := 0; i < settings.MaxDepth+1; i++ {
+			dst = map[string]any{"nest": dst}
+			src = map[string]any{"nest": src}
+		}
+
+		dstMap := dst.(map[string]any)
+		srcMap := src.(map[string]any)
+
+		result := deepMergeN(dstMap, srcMap, 0)
+
+		// Navigate to the leaf.
+		current := result
+		for i := 0; i < settings.MaxDepth+1; i++ {
+			nested, ok := current["nest"].(map[string]any)
+			require.True(t, ok, "expected map at depth %d", i)
+			current = nested
+		}
+
+		// At MaxDepth, src replaces dst wholesale — so dstOnly should NOT exist.
+		assert.Equal(t, "from-src", current["srcOnly"], "srcOnly should be present")
+		assert.Equal(t, "src-val", current["shared"], "shared should be src value")
+		_, hasDstOnly := current["dstOnly"]
+		assert.False(t, hasDstOnly, "dstOnly should be absent because src replaced dst at MaxDepth")
+	})
+
+	t.Run("merges recursively below MaxDepth", func(t *testing.T) {
+		t.Parallel()
+
+		// With MaxDepth wrappings, the leaf maps sit at depth MaxDepth-1
+		// (one below the cutoff), so they should be recursively merged.
+		dstLeaf := map[string]any{"dstOnly": "kept", "shared": "dst-val"}
+		srcLeaf := map[string]any{"srcOnly": "added", "shared": "src-val"}
+
+		var dst, src any = dstLeaf, srcLeaf
+		for i := 0; i < settings.MaxDepth; i++ {
+			dst = map[string]any{"nest": dst}
+			src = map[string]any{"nest": src}
+		}
+
+		dstMap := dst.(map[string]any)
+		srcMap := src.(map[string]any)
+
+		result := deepMergeN(dstMap, srcMap, 0)
+
+		// Navigate to the leaf.
+		current := result
+		for i := 0; i < settings.MaxDepth; i++ {
+			nested, ok := current["nest"].(map[string]any)
+			require.True(t, ok, "expected map at depth %d", i)
+			current = nested
+		}
+
+		// Below MaxDepth — recursive merge should happen, so dstOnly IS present.
+		assert.Equal(t, "kept", current["dstOnly"], "dstOnly should be preserved by merge")
+		assert.Equal(t, "added", current["srcOnly"], "srcOnly should be added by merge")
+		assert.Equal(t, "src-val", current["shared"], "shared should be overridden by src")
+	})
+
+	t.Run("depth parameter offsets the limit", func(t *testing.T) {
+		t.Parallel()
+
+		dst := map[string]any{
+			"inner": map[string]any{"a": 1, "b": 2},
+		}
+		src := map[string]any{
+			"inner": map[string]any{"b": 99, "c": 3},
+		}
+
+		// Call with depth == MaxDepth: should NOT recurse into "inner".
+		result := deepMergeN(dst, src, settings.MaxDepth)
+		inner, ok := result["inner"].(map[string]any)
+		require.True(t, ok)
+		// src replaces wholesale, so "a" (dst-only) should be gone.
+		_, hasA := inner["a"]
+		assert.False(t, hasA, "at MaxDepth, src map replaces dst map wholesale")
+		assert.Equal(t, 99, inner["b"])
+		assert.Equal(t, 3, inner["c"])
+	})
+
+	t.Run("depth below MaxDepth recurses", func(t *testing.T) {
+		t.Parallel()
+
+		dst := map[string]any{
+			"inner": map[string]any{"a": 1, "b": 2},
+		}
+		src := map[string]any{
+			"inner": map[string]any{"b": 99, "c": 3},
+		}
+
+		// Call with depth == MaxDepth-1: should recurse into "inner".
+		result := deepMergeN(dst, src, settings.MaxDepth-1)
+		inner, ok := result["inner"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, 1, inner["a"], "a preserved from dst")
+		assert.Equal(t, 99, inner["b"], "b overridden by src")
+		assert.Equal(t, 3, inner["c"], "c added from src")
+	})
+}
+
+func TestApplyDenySubKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		val      any
+		patterns []string
+		want     any
+	}{
+		{
+			name: "wildcard strips key recursively in nested maps",
+			val: map[string]any{
+				"github": map[string]any{
+					"url":    "https://github.com",
+					"apiKey": "ghp_secret",
+				},
+				"gitlab": map[string]any{
+					"url":    "https://gitlab.com",
+					"apiKey": "glpat_secret",
+					"nested": map[string]any{
+						"apiKey": "deep-secret",
+						"safe":   "keep",
+					},
+				},
+			},
+			patterns: []string{"*.apiKey"},
+			want: map[string]any{
+				"github": map[string]any{
+					"url": "https://github.com",
+				},
+				"gitlab": map[string]any{
+					"url": "https://gitlab.com",
+					"nested": map[string]any{
+						"safe": "keep",
+					},
+				},
+			},
+		},
+		{
+			name: "plain pattern deletes top-level key only",
+			val: map[string]any{
+				"apiKey": "top-level",
+				"nested": map[string]any{
+					"apiKey": "should-remain",
+				},
+			},
+			patterns: []string{"apiKey"},
+			want: map[string]any{
+				"nested": map[string]any{
+					"apiKey": "should-remain",
+				},
+			},
+		},
+		{
+			name: "multiple patterns applied together",
+			val: map[string]any{
+				"provider": map[string]any{
+					"apiKey": "secret",
+					"token":  "also-secret",
+					"url":    "https://example.com",
+				},
+			},
+			patterns: []string{"*.apiKey", "*.token"},
+			want: map[string]any{
+				"provider": map[string]any{
+					"url": "https://example.com",
+				},
+			},
+		},
+		{
+			name:     "non-map value is returned unchanged",
+			val:      "scalar-string",
+			patterns: []string{"*.apiKey"},
+			want:     "scalar-string",
+		},
+		{
+			name:     "nil value is returned unchanged",
+			val:      nil,
+			patterns: []string{"*.apiKey"},
+			want:     nil,
+		},
+		{
+			name: "empty patterns is a no-op",
+			val: map[string]any{
+				"apiKey": "kept",
+			},
+			patterns: []string{},
+			want: map[string]any{
+				"apiKey": "kept",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := applyDenySubKeys(tt.val, tt.patterns)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyDenySubKeys_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a realistic scenario: multi-level provider config with
+	// API keys at various depths, all stripped by "*.apiKey".
+	data := map[string]any{
+		"providers": map[string]any{
+			"github": map[string]any{
+				"url":    "https://github.com",
+				"apiKey": "ghp_top",
+				"oauth": map[string]any{
+					"apiKey":      "ghp_oauth",
+					"callbackURL": "http://localhost/callback",
+				},
+			},
+			"gitlab": map[string]any{
+				"url":    "https://gitlab.com",
+				"apiKey": "glpat_top",
+			},
+		},
+		"theme": "dark",
+	}
+
+	filter := &settings.FieldFilter{
+		AllowKeys:   []string{"providers", "theme"},
+		DenySubKeys: map[string][]string{"providers": {"*.apiKey"}},
+	}
+
+	result := applyFilter(data, filter)
+
+	// theme should be preserved.
+	assert.Equal(t, "dark", result["theme"])
+
+	providers, ok := result["providers"].(map[string]any)
+	require.True(t, ok)
+
+	// github
+	gh, ok := providers["github"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "https://github.com", gh["url"])
+	_, hasKey := gh["apiKey"]
+	assert.False(t, hasKey, "github top-level apiKey should be stripped")
+
+	oauth, ok := gh["oauth"].(map[string]any)
+	require.True(t, ok)
+	_, hasKey = oauth["apiKey"]
+	assert.False(t, hasKey, "github oauth apiKey should be stripped")
+	assert.Equal(t, "http://localhost/callback", oauth["callbackURL"])
+
+	// gitlab
+	gl, ok := providers["gitlab"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "https://gitlab.com", gl["url"])
+	_, hasKey = gl["apiKey"]
+	assert.False(t, hasKey, "gitlab apiKey should be stripped")
+}

--- a/internal/infra/settings/injector_test.go
+++ b/internal/infra/settings/injector_test.go
@@ -1,0 +1,641 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package settings
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/brood-box/pkg/domain/settings"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// setupRootfs creates the sandbox home directory inside rootfsPath.
+func setupRootfs(t *testing.T, rootfsPath string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(rootfsPath, sandboxHome), 0755))
+}
+
+func TestFSInjector_File(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, hostHome string)
+		entry   settings.Entry
+		check   func(t *testing.T, rootfs string)
+		wantErr string
+	}{
+		{
+			name: "copies file with correct permissions",
+			setup: func(t *testing.T, hostHome string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(
+					filepath.Join(hostHome, "settings.json"),
+					[]byte(`{"key":"value"}`), 0644))
+			},
+			entry: settings.Entry{
+				HostPath:  "settings.json",
+				GuestPath: "settings.json",
+				Kind:      settings.KindFile,
+			},
+			check: func(t *testing.T, rootfs string) {
+				t.Helper()
+				dst := filepath.Join(rootfs, sandboxHome, "settings.json")
+				data, err := os.ReadFile(dst)
+				require.NoError(t, err)
+				assert.Equal(t, `{"key":"value"}`, string(data))
+
+				info, err := os.Stat(dst)
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(filePerm), info.Mode().Perm())
+			},
+		},
+		{
+			name:  "optional missing source is no-op",
+			setup: func(_ *testing.T, _ string) {},
+			entry: settings.Entry{
+				HostPath:  "nonexistent.json",
+				GuestPath: "nonexistent.json",
+				Kind:      settings.KindFile,
+				Optional:  true,
+			},
+			check: func(t *testing.T, rootfs string) {
+				t.Helper()
+				_, err := os.Stat(filepath.Join(rootfs, sandboxHome, "nonexistent.json"))
+				assert.True(t, os.IsNotExist(err))
+			},
+		},
+		{
+			name: "rejects symlinks",
+			setup: func(t *testing.T, hostHome string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(
+					filepath.Join(hostHome, "real.json"),
+					[]byte("real"), 0644))
+				require.NoError(t, os.Symlink("real.json",
+					filepath.Join(hostHome, "link.json")))
+			},
+			entry: settings.Entry{
+				HostPath:  "link.json",
+				GuestPath: "link.json",
+				Kind:      settings.KindFile,
+			},
+			check: func(t *testing.T, rootfs string) {
+				t.Helper()
+				_, err := os.Stat(filepath.Join(rootfs, sandboxHome, "link.json"))
+				assert.True(t, os.IsNotExist(err))
+			},
+		},
+		{
+			name: "rejects path traversal",
+			setup: func(t *testing.T, hostHome string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(
+					filepath.Join(hostHome, "data.json"),
+					[]byte("data"), 0644))
+			},
+			entry: settings.Entry{
+				HostPath:  "data.json",
+				GuestPath: "../../etc/passwd",
+				Kind:      settings.KindFile,
+			},
+			wantErr: "path containment",
+		},
+		{
+			name: "rejects oversized file",
+			setup: func(t *testing.T, hostHome string) {
+				t.Helper()
+				big := make([]byte, settings.MaxFileSize+1)
+				require.NoError(t, os.WriteFile(
+					filepath.Join(hostHome, "big.bin"),
+					big, 0644))
+			},
+			entry: settings.Entry{
+				HostPath:  "big.bin",
+				GuestPath: "big.bin",
+				Kind:      settings.KindFile,
+			},
+			wantErr: "exceeds max size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hostHome := t.TempDir()
+			rootfs := t.TempDir()
+			setupRootfs(t, rootfs)
+
+			tt.setup(t, hostHome)
+
+			inj := NewFSInjector(testLogger())
+			manifest := settings.Manifest{Entries: []settings.Entry{tt.entry}}
+			err := inj.Inject(rootfs, hostHome, manifest)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, rootfs)
+			}
+		})
+	}
+}
+
+func TestFSInjector_Directory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, hostHome string)
+		entry   settings.Entry
+		check   func(t *testing.T, rootfs string)
+		wantErr string
+	}{
+		{
+			name: "recursively copies directory",
+			setup: func(t *testing.T, hostHome string) {
+				t.Helper()
+				dir := filepath.Join(hostHome, "config", "sub")
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(hostHome, "config", "a.txt"),
+					[]byte("aaa"), 0644))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, "b.txt"),
+					[]byte("bbb"), 0644))
+			},
+			entry: settings.Entry{
+				HostPath:  "config",
+				GuestPath: "config",
+				Kind:      settings.KindDirectory,
+			},
+			check: func(t *testing.T, rootfs string) {
+				t.Helper()
+				dataA, err := os.ReadFile(filepath.Join(rootfs, sandboxHome, "config", "a.txt"))
+				require.NoError(t, err)
+				assert.Equal(t, "aaa", string(dataA))
+
+				dataB, err := os.ReadFile(filepath.Join(rootfs, sandboxHome, "config", "sub", "b.txt"))
+				require.NoError(t, err)
+				assert.Equal(t, "bbb", string(dataB))
+			},
+		},
+		{
+			name: "respects depth limit",
+			setup: func(t *testing.T, hostHome string) {
+				t.Helper()
+				// Build a chain deeper than MaxDepth.
+				path := filepath.Join(hostHome, "deep")
+				for i := 0; i < settings.MaxDepth+2; i++ {
+					path = filepath.Join(path, "d")
+				}
+				require.NoError(t, os.MkdirAll(path, 0755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(path, "file.txt"),
+					[]byte("too deep"), 0644))
+			},
+			entry: settings.Entry{
+				HostPath:  "deep",
+				GuestPath: "deep",
+				Kind:      settings.KindDirectory,
+			},
+			check: func(t *testing.T, rootfs string) {
+				t.Helper()
+				// The deeply nested file should not exist.
+				path := filepath.Join(rootfs, sandboxHome, "deep")
+				for i := 0; i < settings.MaxDepth+2; i++ {
+					path = filepath.Join(path, "d")
+				}
+				_, err := os.Stat(filepath.Join(path, "file.txt"))
+				assert.True(t, os.IsNotExist(err))
+			},
+		},
+		{
+			name: "skips symlinks in directory",
+			setup: func(t *testing.T, hostHome string) {
+				t.Helper()
+				dir := filepath.Join(hostHome, "withlink")
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, "real.txt"),
+					[]byte("real"), 0644))
+				require.NoError(t, os.Symlink("real.txt",
+					filepath.Join(dir, "link.txt")))
+			},
+			entry: settings.Entry{
+				HostPath:  "withlink",
+				GuestPath: "withlink",
+				Kind:      settings.KindDirectory,
+			},
+			check: func(t *testing.T, rootfs string) {
+				t.Helper()
+				// Real file should exist.
+				data, err := os.ReadFile(filepath.Join(rootfs, sandboxHome, "withlink", "real.txt"))
+				require.NoError(t, err)
+				assert.Equal(t, "real", string(data))
+
+				// Symlink should not.
+				_, err = os.Stat(filepath.Join(rootfs, sandboxHome, "withlink", "link.txt"))
+				assert.True(t, os.IsNotExist(err))
+			},
+		},
+		{
+			name: "respects file count limit",
+			setup: func(t *testing.T, hostHome string) {
+				t.Helper()
+				dir := filepath.Join(hostHome, "many")
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				// Create MaxFileCount + 5 files.
+				for i := 0; i < settings.MaxFileCount+5; i++ {
+					name := filepath.Join(dir, fmt.Sprintf("f%04d.txt", i))
+					require.NoError(t, os.WriteFile(name, []byte("x"), 0644))
+				}
+			},
+			entry: settings.Entry{
+				HostPath:  "many",
+				GuestPath: "many",
+				Kind:      settings.KindDirectory,
+			},
+			wantErr: "file count would exceed limit",
+		},
+		{
+			name: "respects total size limit",
+			setup: func(t *testing.T, hostHome string) {
+				t.Helper()
+				dir := filepath.Join(hostHome, "bigdir")
+				require.NoError(t, os.MkdirAll(dir, 0755))
+				// Write files that together exceed MaxTotalSize.
+				// Each file is MaxFileSize (1 MiB), write enough to exceed 50 MiB.
+				chunk := make([]byte, settings.MaxFileSize)
+				count := int(settings.MaxTotalSize/settings.MaxFileSize) + 2
+				for i := 0; i < count; i++ {
+					name := filepath.Join(dir, fmt.Sprintf("chunk%d.bin", i))
+					require.NoError(t, os.WriteFile(name, chunk, 0644))
+				}
+			},
+			entry: settings.Entry{
+				HostPath:  "bigdir",
+				GuestPath: "bigdir",
+				Kind:      settings.KindDirectory,
+			},
+			wantErr: "aggregate size would exceed limit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hostHome := t.TempDir()
+			rootfs := t.TempDir()
+			setupRootfs(t, rootfs)
+
+			tt.setup(t, hostHome)
+
+			inj := NewFSInjector(testLogger())
+			manifest := settings.Manifest{Entries: []settings.Entry{tt.entry}}
+			err := inj.Inject(rootfs, hostHome, manifest)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, rootfs)
+			}
+		})
+	}
+}
+
+func TestFSInjector_MergeFileJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		hostContent  string
+		guestContent string // empty means no pre-existing guest file
+		entry        settings.Entry
+		wantKeys     map[string]any
+		wantAbsent   []string
+	}{
+		{
+			name:        "allowlist filtering",
+			hostContent: `{"theme":"dark","apiKey":"secret","editor":"vim"}`,
+			entry: settings.Entry{
+				HostPath:  "config.json",
+				GuestPath: "config.json",
+				Kind:      settings.KindMergeFile,
+				Format:    "json",
+				Filter: &settings.FieldFilter{
+					AllowKeys: []string{"theme", "editor"},
+				},
+			},
+			wantKeys:   map[string]any{"theme": "dark", "editor": "vim"},
+			wantAbsent: []string{"apiKey"},
+		},
+		{
+			name:        "deny sub-keys with wildcard",
+			hostContent: `{"providers":{"github":{"url":"https://github.com","apiKey":"ghp_secret"},"gitlab":{"url":"https://gitlab.com","apiKey":"glpat_secret"}},"theme":"dark"}`,
+			entry: settings.Entry{
+				HostPath:  "config.json",
+				GuestPath: "config.json",
+				Kind:      settings.KindMergeFile,
+				Format:    "json",
+				Filter: &settings.FieldFilter{
+					AllowKeys:   []string{"providers", "theme"},
+					DenySubKeys: map[string][]string{"providers": {"*.apiKey"}},
+				},
+			},
+			wantKeys:   map[string]any{"theme": "dark"},
+			wantAbsent: []string{
+				// apiKey should be stripped from both providers.
+			},
+		},
+		{
+			name:         "preserves existing guest keys",
+			hostContent:  `{"theme":"dark","editor":"vim"}`,
+			guestContent: `{"credentials":"token123","theme":"light"}`,
+			entry: settings.Entry{
+				HostPath:  "config.json",
+				GuestPath: "config.json",
+				Kind:      settings.KindMergeFile,
+				Format:    "json",
+			},
+			wantKeys: map[string]any{"credentials": "token123", "theme": "dark", "editor": "vim"},
+		},
+		{
+			name:        "merge into empty rootfs",
+			hostContent: `{"setting":"value"}`,
+			entry: settings.Entry{
+				HostPath:  "config.json",
+				GuestPath: "new-config.json",
+				Kind:      settings.KindMergeFile,
+				Format:    "json",
+			},
+			wantKeys: map[string]any{"setting": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hostHome := t.TempDir()
+			rootfs := t.TempDir()
+			setupRootfs(t, rootfs)
+
+			require.NoError(t, os.WriteFile(
+				filepath.Join(hostHome, tt.entry.HostPath),
+				[]byte(tt.hostContent), 0644))
+
+			if tt.guestContent != "" {
+				guestPath := filepath.Join(rootfs, sandboxHome, tt.entry.GuestPath)
+				require.NoError(t, os.MkdirAll(filepath.Dir(guestPath), 0755))
+				require.NoError(t, os.WriteFile(guestPath, []byte(tt.guestContent), 0600))
+			}
+
+			inj := NewFSInjector(testLogger())
+			manifest := settings.Manifest{Entries: []settings.Entry{tt.entry}}
+			err := inj.Inject(rootfs, hostHome, manifest)
+			require.NoError(t, err)
+
+			dstPath := filepath.Join(rootfs, sandboxHome, tt.entry.GuestPath)
+			data, err := os.ReadFile(dstPath)
+			require.NoError(t, err)
+
+			var result map[string]any
+			require.NoError(t, json.Unmarshal(data, &result))
+
+			for k, v := range tt.wantKeys {
+				assert.Equal(t, v, result[k], "key %q", k)
+			}
+
+			for _, k := range tt.wantAbsent {
+				_, exists := result[k]
+				assert.False(t, exists, "key %q should be absent", k)
+			}
+
+			// Special check for deny sub-keys test: verify apiKey is stripped.
+			if tt.name == "deny sub-keys with wildcard" {
+				providers, ok := result["providers"].(map[string]any)
+				require.True(t, ok)
+				for name, prov := range providers {
+					provMap, ok := prov.(map[string]any)
+					require.True(t, ok, "provider %q", name)
+					_, hasAPIKey := provMap["apiKey"]
+					assert.False(t, hasAPIKey, "provider %q should not have apiKey", name)
+					_, hasURL := provMap["url"]
+					assert.True(t, hasURL, "provider %q should still have url", name)
+				}
+			}
+		})
+	}
+}
+
+func TestFSInjector_MergeFileTOML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		hostContent  string
+		guestContent string
+		entry        settings.Entry
+		wantKeys     map[string]any
+		wantAbsent   []string
+	}{
+		{
+			name:        "allowlist filtering TOML",
+			hostContent: "theme = \"dark\"\napiKey = \"secret\"\neditor = \"vim\"\n",
+			entry: settings.Entry{
+				HostPath:  "config.toml",
+				GuestPath: "config.toml",
+				Kind:      settings.KindMergeFile,
+				Format:    "toml",
+				Filter: &settings.FieldFilter{
+					AllowKeys: []string{"theme", "editor"},
+				},
+			},
+			wantKeys:   map[string]any{"theme": "dark", "editor": "vim"},
+			wantAbsent: []string{"apiKey"},
+		},
+		{
+			name:         "preserves existing guest keys TOML",
+			hostContent:  "theme = \"dark\"\n",
+			guestContent: "credentials = \"token123\"\ntheme = \"light\"\n",
+			entry: settings.Entry{
+				HostPath:  "config.toml",
+				GuestPath: "config.toml",
+				Kind:      settings.KindMergeFile,
+				Format:    "toml",
+			},
+			wantKeys: map[string]any{"credentials": "token123", "theme": "dark"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hostHome := t.TempDir()
+			rootfs := t.TempDir()
+			setupRootfs(t, rootfs)
+
+			require.NoError(t, os.WriteFile(
+				filepath.Join(hostHome, tt.entry.HostPath),
+				[]byte(tt.hostContent), 0644))
+
+			if tt.guestContent != "" {
+				guestPath := filepath.Join(rootfs, sandboxHome, tt.entry.GuestPath)
+				require.NoError(t, os.MkdirAll(filepath.Dir(guestPath), 0755))
+				require.NoError(t, os.WriteFile(guestPath, []byte(tt.guestContent), 0600))
+			}
+
+			inj := NewFSInjector(testLogger())
+			manifest := settings.Manifest{Entries: []settings.Entry{tt.entry}}
+			err := inj.Inject(rootfs, hostHome, manifest)
+			require.NoError(t, err)
+
+			dstPath := filepath.Join(rootfs, sandboxHome, tt.entry.GuestPath)
+			data, err := os.ReadFile(dstPath)
+			require.NoError(t, err)
+
+			var result map[string]any
+			require.NoError(t, toml.Unmarshal(data, &result))
+
+			for k, v := range tt.wantKeys {
+				assert.Equal(t, v, result[k], "key %q", k)
+			}
+
+			for _, k := range tt.wantAbsent {
+				_, exists := result[k]
+				assert.False(t, exists, "key %q should be absent", k)
+			}
+		})
+	}
+}
+
+func TestStripJSONC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "strips line comments",
+			input: "{\n  // this is a comment\n  \"key\": \"value\"\n}",
+			want:  "{\n  \n  \"key\": \"value\"\n}",
+		},
+		{
+			name:  "strips block comments",
+			input: "{\n  /* block\n  comment */\n  \"key\": \"value\"\n}",
+			want:  "{\n  \n  \"key\": \"value\"\n}",
+		},
+		{
+			name:  "preserves strings with slashes",
+			input: `{"url": "https://example.com/path"}`,
+			want:  `{"url": "https://example.com/path"}`,
+		},
+		{
+			name:  "preserves escaped quotes in strings",
+			input: `{"msg": "say \"hello\""}`,
+			want:  `{"msg": "say \"hello\""}`,
+		},
+		{
+			name:  "handles mixed comments",
+			input: "{\n  // line\n  \"a\": 1, /* inline */ \"b\": 2\n}",
+			want:  "{\n  \n  \"a\": 1,  \"b\": 2\n}",
+		},
+		{
+			name:  "trailing commas",
+			input: `{"a": 1, "b": [2, 3,], }`,
+			want:  `{"a": 1, "b": [2, 3] }`,
+		},
+		{
+			name:  "trailing comma after comment",
+			input: "{\"a\": 1, // comment\n}",
+			want:  "{\"a\": 1 \n}",
+		},
+		{
+			name:  "no comments passthrough",
+			input: `{"key": "value"}`,
+			want:  `{"key": "value"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := stripJSONC([]byte(tt.input))
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestFSInjector_MergeFileJSONC(t *testing.T) {
+	t.Parallel()
+
+	hostHome := t.TempDir()
+	rootfs := t.TempDir()
+	setupRootfs(t, rootfs)
+
+	hostContent := `{
+  // Editor preference
+  "theme": "dark",
+  /* API credentials - should be filtered */
+  "apiKey": "secret",
+  "editor": "vim"
+}`
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(hostHome, "settings.jsonc"),
+		[]byte(hostContent), 0644))
+
+	entry := settings.Entry{
+		HostPath:  "settings.jsonc",
+		GuestPath: "settings.json",
+		Kind:      settings.KindMergeFile,
+		Format:    "jsonc",
+		Filter: &settings.FieldFilter{
+			AllowKeys: []string{"theme", "editor"},
+		},
+	}
+
+	inj := NewFSInjector(testLogger())
+	manifest := settings.Manifest{Entries: []settings.Entry{entry}}
+	err := inj.Inject(rootfs, hostHome, manifest)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(rootfs, sandboxHome, "settings.json"))
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(data, &result))
+
+	assert.Equal(t, "dark", result["theme"])
+	assert.Equal(t, "vim", result["editor"])
+	_, hasAPIKey := result["apiKey"]
+	assert.False(t, hasAPIKey)
+}

--- a/internal/infra/settings/jsonc.go
+++ b/internal/infra/settings/jsonc.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package settings
+
+// stripJSONC removes // and /* */ comments and trailing commas from JSONC
+// data while respecting string literals. Returns valid JSON.
+func stripJSONC(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+	i := 0
+	n := len(data)
+
+	for i < n {
+		// Inside a string literal: copy until closing quote.
+		if data[i] == '"' {
+			out = append(out, data[i])
+			i++
+			for i < n {
+				if data[i] == '\\' && i+1 < n {
+					out = append(out, data[i], data[i+1])
+					i += 2
+					continue
+				}
+				out = append(out, data[i])
+				if data[i] == '"' {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		// Line comment: skip until end of line.
+		if i+1 < n && data[i] == '/' && data[i+1] == '/' {
+			i += 2
+			for i < n && data[i] != '\n' {
+				i++
+			}
+			continue
+		}
+
+		// Block comment: skip until closing */.
+		if i+1 < n && data[i] == '/' && data[i+1] == '*' {
+			i += 2
+			for i+1 < n {
+				if data[i] == '*' && data[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		out = append(out, data[i])
+		i++
+	}
+
+	// Strip trailing commas before } and ].
+	return stripTrailingCommas(out)
+}
+
+// stripTrailingCommas removes commas immediately followed by } or ]
+// (with optional whitespace between).
+func stripTrailingCommas(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+	i := 0
+	n := len(data)
+
+	for i < n {
+		// Inside a string literal: copy verbatim.
+		if data[i] == '"' {
+			out = append(out, data[i])
+			i++
+			for i < n {
+				if data[i] == '\\' && i+1 < n {
+					out = append(out, data[i], data[i+1])
+					i += 2
+					continue
+				}
+				out = append(out, data[i])
+				if data[i] == '"' {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		if data[i] == ',' {
+			// Look ahead past whitespace for } or ].
+			j := i + 1
+			for j < n && (data[j] == ' ' || data[j] == '\t' || data[j] == '\n' || data[j] == '\r') {
+				j++
+			}
+			if j < n && (data[j] == '}' || data[j] == ']') {
+				// Skip the comma, keep the whitespace and closing bracket.
+				i++
+				continue
+			}
+		}
+
+		out = append(out, data[i])
+		i++
+	}
+
+	return out
+}

--- a/internal/infra/vm/mcpconfig.go
+++ b/internal/infra/vm/mcpconfig.go
@@ -71,7 +71,12 @@ func injectClaudeCodeMCP(rootfsPath, gatewayIP string, port uint16, chown ChownF
 		return err
 	}
 
-	if err := mergeJSONKey(homeDir, ".claude.json", "mcpServers", servers, chown); err != nil {
+	// Deep-merge to preserve user MCP servers injected by settings hook.
+	serversMap := make(map[string]any, len(servers))
+	for k, v := range servers {
+		serversMap[k] = v
+	}
+	if err := mergeJSONMapEntries(homeDir, ".claude.json", "mcpServers", serversMap, chown); err != nil {
 		return err
 	}
 
@@ -102,7 +107,7 @@ func injectCodexMCP(rootfsPath, gatewayIP string, port uint16, chown ChownFunc) 
 		return fmt.Errorf("creating ~/.codex dir: %w", err)
 	}
 
-	return mergeTOMLKey(codexDir, "config.toml", "mcp_servers", map[string]any{
+	return mergeTOMLMapEntries(codexDir, "config.toml", "mcp_servers", map[string]any{
 		"sandbox-tools": map[string]any{
 			"url": mcpURL,
 		},
@@ -141,7 +146,12 @@ func injectOpenCodeMCP(rootfsPath, gatewayIP string, port uint16, chown ChownFun
 		return fmt.Errorf("creating ~/.config/opencode dir: %w", err)
 	}
 
-	return mergeJSONKey(opencodeDir, "opencode.json", "mcp", servers, chown)
+	// Deep-merge to preserve user MCP servers injected by settings hook.
+	serversMap := make(map[string]any, len(servers))
+	for k, v := range servers {
+		serversMap[k] = v
+	}
+	return mergeJSONMapEntries(opencodeDir, "opencode.json", "mcp", serversMap, chown)
 }
 
 // --- helpers ---
@@ -184,10 +194,61 @@ func mergeJSONKey(dir, filename, key string, value any, chown ChownFunc) error {
 	return chown(path, sandboxUID, sandboxGID)
 }
 
-// mergeTOMLKey reads an existing TOML file (if any) at dir/filename, sets
-// the given top-level key to value, and writes the result back. If the file
-// does not exist, a new document with just [key] is created.
-func mergeTOMLKey(dir, filename, key string, value any, chown ChownFunc) error {
+// mergeJSONMapEntries reads an existing JSON file, merges entries from value
+// into the map at key, and writes back. Individual map entries from value
+// override existing entries with the same name, but other entries are preserved.
+// This is a single-level merge: each map entry is replaced atomically (not
+// recursively). This is correct for MCP server maps where each server entry
+// is an independent unit.
+func mergeJSONMapEntries(dir, filename, key string, value map[string]any, chown ChownFunc) error {
+	path := filepath.Join(dir, filename)
+
+	existing := make(map[string]json.RawMessage)
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return fmt.Errorf("parsing existing %s: %w", filename, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("reading existing %s: %w", filename, err)
+	}
+
+	// Parse existing map at key (if any).
+	existingMap := make(map[string]any)
+	if raw, ok := existing[key]; ok {
+		if err := json.Unmarshal(raw, &existingMap); err != nil {
+			// Not a map — replace entirely.
+			existingMap = make(map[string]any)
+		}
+	}
+
+	// Merge new entries into existing map.
+	for k, v := range value {
+		existingMap[k] = v
+	}
+
+	raw, err := json.Marshal(existingMap)
+	if err != nil {
+		return fmt.Errorf("marshaling %s value for %s: %w", key, filename, err)
+	}
+	existing[key] = raw
+
+	merged, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling merged %s: %w", filename, err)
+	}
+
+	if err := os.WriteFile(path, append(merged, '\n'), 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", filename, err)
+	}
+
+	return chown(path, sandboxUID, sandboxGID)
+}
+
+// mergeTOMLMapEntries reads an existing TOML file, merges entries from value
+// into the table at key, and writes back. Individual entries from value
+// override existing entries with the same name, but other entries are preserved.
+// This is a single-level merge (see mergeJSONMapEntries for rationale).
+func mergeTOMLMapEntries(dir, filename, key string, value map[string]any, chown ChownFunc) error {
 	path := filepath.Join(dir, filename)
 
 	existing := make(map[string]any)
@@ -199,7 +260,19 @@ func mergeTOMLKey(dir, filename, key string, value any, chown ChownFunc) error {
 		return fmt.Errorf("reading existing %s: %w", filename, err)
 	}
 
-	existing[key] = value
+	// Parse existing map at key (if any).
+	existingMap := make(map[string]any)
+	if raw, ok := existing[key]; ok {
+		if m, ok := raw.(map[string]any); ok {
+			existingMap = m
+		}
+	}
+
+	// Merge new entries into existing map.
+	for k, v := range value {
+		existingMap[k] = v
+	}
+	existing[key] = existingMap
 
 	merged, err := toml.Marshal(existing)
 	if err != nil {

--- a/internal/infra/vm/mcpconfig_test.go
+++ b/internal/infra/vm/mcpconfig_test.go
@@ -428,16 +428,16 @@ func TestInjectClaudeCodeMCP_PreservesExistingKeys(t *testing.T) {
 	assert.JSONEq(t, `"dark"`, string(raw["theme"]))
 }
 
-func TestInjectClaudeCodeMCP_OverwritesExistingMCPServers(t *testing.T) {
+func TestInjectClaudeCodeMCP_PreservesExistingMCPServers(t *testing.T) {
 	t.Parallel()
 
 	rootfs := setupRootfs(t)
 	chown, _ := recordingChown()
 	configPath := filepath.Join(rootfs, sandboxHome, ".claude.json")
 
-	// Pre-populate with a stale MCP server entry.
-	stale := `{"mcpServers": {"old-server": {"type": "http", "url": "http://old:1234/mcp"}}}`
-	require.NoError(t, os.WriteFile(configPath, []byte(stale), 0o644))
+	// Pre-populate with a user MCP server entry.
+	existing := `{"mcpServers": {"user-server": {"type": "http", "url": "http://user:1234/mcp"}}}`
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o644))
 
 	err := injectClaudeCodeMCP(rootfs, "192.168.127.1", 4483, chown)
 	require.NoError(t, err)
@@ -449,8 +449,9 @@ func TestInjectClaudeCodeMCP_OverwritesExistingMCPServers(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &cfg))
 
 	assert.Contains(t, cfg.MCPServers, "sandbox-tools", "new entry must be present")
-	assert.NotContains(t, cfg.MCPServers, "old-server", "stale entry must be replaced")
+	assert.Contains(t, cfg.MCPServers, "user-server", "existing user entry must be preserved")
 	assert.Equal(t, "http://192.168.127.1:4483/mcp", cfg.MCPServers["sandbox-tools"].URL)
+	assert.Equal(t, "http://user:1234/mcp", cfg.MCPServers["user-server"].URL)
 }
 
 func TestInjectOpenCodeMCP_PreservesExistingKeys(t *testing.T) {
@@ -517,6 +518,119 @@ func TestInjectCodexMCP_PreservesExistingSections(t *testing.T) {
 	sandboxTools, ok := mcpServers["sandbox-tools"].(map[string]any)
 	require.True(t, ok, "sandbox-tools must be present")
 	assert.Equal(t, "http://192.168.127.1:4483/mcp", sandboxTools["url"])
+}
+
+func TestInjectCodexMCP_PreservesExistingMCPServers(t *testing.T) {
+	t.Parallel()
+
+	rootfs := setupRootfs(t)
+	chown, _ := recordingChown()
+	codexDir := filepath.Join(rootfs, sandboxHome, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	configPath := filepath.Join(codexDir, "config.toml")
+
+	// Pre-populate with a user MCP server entry.
+	existing := "[mcp_servers.user-tool]\nurl = 'http://user:1234/mcp'\n"
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o644))
+
+	err := injectCodexMCP(rootfs, "192.168.127.1", 4483, chown)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, toml.Unmarshal(data, &parsed))
+
+	mcpServers, ok := parsed["mcp_servers"].(map[string]any)
+	require.True(t, ok, "mcp_servers must be present")
+
+	// Verify sandbox-tools was injected.
+	sandboxTools, ok := mcpServers["sandbox-tools"].(map[string]any)
+	require.True(t, ok, "sandbox-tools must be present")
+	assert.Equal(t, "http://192.168.127.1:4483/mcp", sandboxTools["url"])
+
+	// Verify user-tool is preserved.
+	userTool, ok := mcpServers["user-tool"].(map[string]any)
+	require.True(t, ok, "user-tool must be preserved")
+	assert.Equal(t, "http://user:1234/mcp", userTool["url"])
+}
+
+func TestInjectOpenCodeMCP_PreservesExistingMCPServers(t *testing.T) {
+	t.Parallel()
+
+	rootfs := setupRootfs(t)
+	chown, _ := recordingChown()
+	opencodeDir := filepath.Join(rootfs, sandboxHome, ".config", "opencode")
+	require.NoError(t, os.MkdirAll(opencodeDir, 0o755))
+	configPath := filepath.Join(opencodeDir, "opencode.json")
+
+	// Pre-populate with a user MCP server entry.
+	existing := `{"mcp": {"user-tool": {"type": "remote", "url": "http://user:1234"}}}`
+	require.NoError(t, os.WriteFile(configPath, []byte(existing), 0o644))
+
+	err := injectOpenCodeMCP(rootfs, "192.168.127.1", 4483, chown)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var cfg openCodeConfig
+	require.NoError(t, json.Unmarshal(data, &cfg))
+
+	// Verify sandbox-tools was injected.
+	assert.Contains(t, cfg.MCP, "sandbox-tools", "sandbox-tools must be present")
+	assert.Equal(t, "http://192.168.127.1:4483/mcp", cfg.MCP["sandbox-tools"].URL)
+
+	// Verify user-tool is preserved.
+	assert.Contains(t, cfg.MCP, "user-tool", "user-tool must be preserved")
+	assert.Equal(t, "http://user:1234", cfg.MCP["user-tool"].URL)
+}
+
+func TestMergeJSONMapEntries_CorruptFile(t *testing.T) {
+	t.Parallel()
+
+	rootfs := setupRootfs(t)
+	chown, _ := recordingChown()
+	dir := filepath.Join(rootfs, sandboxHome)
+
+	// Write invalid JSON.
+	corruptPath := filepath.Join(dir, "corrupt.json")
+	require.NoError(t, os.WriteFile(corruptPath, []byte(`{not valid json`), 0o644))
+
+	err := mergeJSONMapEntries(dir, "corrupt.json", "key", map[string]any{
+		"new-entry": map[string]any{"url": "http://localhost"},
+	}, chown)
+	assert.Error(t, err, "should fail on corrupt JSON")
+	assert.Contains(t, err.Error(), "parsing existing")
+}
+
+func TestMergeJSONMapEntries_NonMapValue(t *testing.T) {
+	t.Parallel()
+
+	rootfs := setupRootfs(t)
+	chown, _ := recordingChown()
+	dir := filepath.Join(rootfs, sandboxHome)
+
+	// Write JSON where the target key is a string, not a map.
+	filePath := filepath.Join(dir, "nonmap.json")
+	require.NoError(t, os.WriteFile(filePath, []byte(`{"key": "string_not_map"}`), 0o644))
+
+	err := mergeJSONMapEntries(dir, "nonmap.json", "key", map[string]any{
+		"new-entry": map[string]any{"url": "http://localhost"},
+	}, chown)
+	require.NoError(t, err, "should succeed by replacing the non-map value")
+
+	data, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	// The key should now contain the injected map, not the old string.
+	var innerMap map[string]any
+	require.NoError(t, json.Unmarshal(raw["key"], &innerMap))
+	assert.Contains(t, innerMap, "new-entry", "new-entry must be present after replacing non-map value")
 }
 
 // setupRootfs creates a minimal rootfs with /home/sandbox/ pre-created,

--- a/internal/infra/vm/runner.go
+++ b/internal/infra/vm/runner.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stacklok/brood-box/pkg/domain/agent"
 	"github.com/stacklok/brood-box/pkg/domain/credential"
+	"github.com/stacklok/brood-box/pkg/domain/settings"
 	domvm "github.com/stacklok/brood-box/pkg/domain/vm"
 )
 
@@ -34,14 +35,15 @@ var _ domvm.VMRunner = (*MicroVMRunner)(nil)
 
 // MicroVMRunner implements VMRunner using the go-microvm library.
 type MicroVMRunner struct {
-	runnerPath      string
-	libDir          string
-	runtimeSource   extract.Source
-	firmwareSource  extract.Source
-	cacheDir        string
-	imageCacheDir   string
-	credentialStore credential.Store
-	logger          *slog.Logger
+	runnerPath       string
+	libDir           string
+	runtimeSource    extract.Source
+	firmwareSource   extract.Source
+	cacheDir         string
+	imageCacheDir    string
+	credentialStore  credential.Store
+	settingsInjector settings.Injector
+	logger           *slog.Logger
 }
 
 // RunnerOption configures a PropolisRunner.
@@ -79,6 +81,12 @@ func WithCacheDir(dir string) RunnerOption {
 // agent credentials into the guest rootfs before boot.
 func WithCredentialStore(store credential.Store) RunnerOption {
 	return func(r *MicroVMRunner) { r.credentialStore = store }
+}
+
+// WithSettingsInjector sets the injector used to copy agent settings
+// (rules, skills, commands, config files) into the guest rootfs.
+func WithSettingsInjector(injector settings.Injector) RunnerOption {
+	return func(r *MicroVMRunner) { r.settingsInjector = injector }
 }
 
 // WithImageCacheDir sets a shared OCI image cache directory. When set, the
@@ -229,6 +237,15 @@ func (r *MicroVMRunner) Start(ctx context.Context, cfg domvm.VMConfig) (domvm.VM
 	if r.credentialStore != nil && len(cfg.CredentialPaths) > 0 {
 		opts = append(opts, microvm.WithRootFSHook(
 			InjectCredentials(r.credentialStore, cfg.AgentName, cfg.CredentialPaths),
+		))
+	}
+
+	// Add settings injection hook if injector and manifest are configured.
+	// Runs after credentials (which creates base config files) and before
+	// MCP config (which deep-merges sandbox-tools on top of user servers).
+	if r.settingsInjector != nil && cfg.SettingsManifest != nil {
+		opts = append(opts, microvm.WithRootFSHook(
+			InjectSettings(r.settingsInjector, cfg.SettingsManifest),
 		))
 	}
 

--- a/internal/infra/vm/settingshook.go
+++ b/internal/infra/vm/settingshook.go
@@ -16,7 +16,7 @@ import (
 // from the host into the guest rootfs before VM boot.
 func InjectSettings(injector settings.Injector, manifest *settings.Manifest) func(string, *image.OCIConfig) error {
 	return func(rootfsPath string, _ *image.OCIConfig) error {
-		if manifest == nil || len(manifest.Entries) == 0 {
+		if injector == nil || manifest == nil || len(manifest.Entries) == 0 {
 			return nil
 		}
 

--- a/internal/infra/vm/settingshook.go
+++ b/internal/infra/vm/settingshook.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vm
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/stacklok/go-microvm/image"
+
+	"github.com/stacklok/brood-box/pkg/domain/settings"
+)
+
+// InjectSettings returns a RootFS hook that copies filtered agent settings
+// from the host into the guest rootfs before VM boot.
+func InjectSettings(injector settings.Injector, manifest *settings.Manifest) func(string, *image.OCIConfig) error {
+	return func(rootfsPath string, _ *image.OCIConfig) error {
+		if manifest == nil || len(manifest.Entries) == 0 {
+			return nil
+		}
+
+		hostHome, err := os.UserHomeDir()
+		if err != nil {
+			slog.Warn("cannot resolve host home for settings injection", "error", err)
+			return nil
+		}
+
+		slog.Debug("injecting agent settings into rootfs",
+			"entries", len(manifest.Entries),
+		)
+
+		return injector.Inject(rootfsPath, hostHome, *manifest)
+	}
+}

--- a/internal/infra/vm/settingshook_test.go
+++ b/internal/infra/vm/settingshook_test.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/brood-box/pkg/domain/settings"
+)
+
+// mockInjector records calls to Inject for verification.
+type mockInjector struct {
+	calls []mockInjectCall
+}
+
+type mockInjectCall struct {
+	RootfsPath  string
+	HostHomeDir string
+	Manifest    settings.Manifest
+}
+
+func (m *mockInjector) Inject(rootfsPath, hostHomeDir string, manifest settings.Manifest) error {
+	m.calls = append(m.calls, mockInjectCall{
+		RootfsPath:  rootfsPath,
+		HostHomeDir: hostHomeDir,
+		Manifest:    manifest,
+	})
+	return nil
+}
+
+func TestInjectSettings_NilManifest(t *testing.T) {
+	t.Parallel()
+
+	inj := &mockInjector{}
+	hook := InjectSettings(inj, nil)
+
+	err := hook(t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, inj.calls, "injector should not be called for nil manifest")
+}
+
+func TestInjectSettings_EmptyManifestEntries(t *testing.T) {
+	t.Parallel()
+
+	inj := &mockInjector{}
+	manifest := &settings.Manifest{Entries: []settings.Entry{}}
+	hook := InjectSettings(inj, manifest)
+
+	err := hook(t.TempDir(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, inj.calls, "injector should not be called for empty manifest entries")
+}
+
+func TestInjectSettings_NonNilManifestCallsInjector(t *testing.T) {
+	t.Parallel()
+
+	inj := &mockInjector{}
+	manifest := &settings.Manifest{
+		Entries: []settings.Entry{
+			{
+				Category:  "settings",
+				HostPath:  "settings.json",
+				GuestPath: "settings.json",
+				Kind:      settings.KindFile,
+			},
+			{
+				Category:  "skills",
+				HostPath:  ".skills",
+				GuestPath: ".skills",
+				Kind:      settings.KindDirectory,
+				Optional:  true,
+			},
+		},
+	}
+
+	rootfs := t.TempDir()
+	hook := InjectSettings(inj, manifest)
+
+	err := hook(rootfs, nil)
+	require.NoError(t, err)
+
+	require.Len(t, inj.calls, 1, "injector should be called exactly once")
+
+	call := inj.calls[0]
+	assert.Equal(t, rootfs, call.RootfsPath)
+	assert.NotEmpty(t, call.HostHomeDir, "host home dir should be resolved")
+	assert.Equal(t, *manifest, call.Manifest)
+	assert.Len(t, call.Manifest.Entries, 2)
+}

--- a/pkg/domain/agent/agent.go
+++ b/pkg/domain/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 
 	"github.com/stacklok/brood-box/pkg/domain/egress"
+	"github.com/stacklok/brood-box/pkg/domain/settings"
 )
 
 // MaxNameLength is the maximum allowed length for an agent name.
@@ -102,6 +103,10 @@ type Agent struct {
 	// DefaultTmpSize is the default /tmp tmpfs size in MiB for this agent.
 	// Zero means use the go-microvm default (256 MiB). Built-in agents default to 512 MiB.
 	DefaultTmpSize uint32
+
+	// SettingsManifest declares host settings to inject into the VM.
+	// Nil means no settings injection for this agent.
+	SettingsManifest *settings.Manifest
 }
 
 // Registry provides access to known agents by name.

--- a/pkg/domain/config/config.go
+++ b/pkg/domain/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	// Git configures git identity and auth forwarding.
 	Git GitConfig `yaml:"git"`
 
+	// SettingsImport configures agent settings injection into the VM.
+	SettingsImport SettingsImportConfig `yaml:"settings_import"`
+
 	// Auth configures credential persistence.
 	Auth AuthConfig `yaml:"auth"`
 
@@ -83,6 +86,72 @@ func (a AuthConfig) SeedHostCredentialsEnabled() bool {
 		return false
 	}
 	return *a.SeedHostCredentials
+}
+
+// SettingsImportConfig configures agent settings injection into the VM.
+type SettingsImportConfig struct {
+	// Enabled controls whether settings injection is active. nil = default true.
+	Enabled *bool `yaml:"enabled,omitempty"`
+
+	// Categories controls which categories to import. nil = all enabled.
+	Categories *SettingsCategoryConfig `yaml:"categories,omitempty"`
+}
+
+// IsEnabled returns whether settings import is enabled.
+// Defaults to true when Enabled is nil.
+func (s SettingsImportConfig) IsEnabled() bool {
+	if s.Enabled == nil {
+		return true
+	}
+	return *s.Enabled
+}
+
+// SettingsCategoryConfig controls which settings categories are imported.
+type SettingsCategoryConfig struct {
+	Settings     *bool `yaml:"settings,omitempty"`
+	Instructions *bool `yaml:"instructions,omitempty"`
+	Rules        *bool `yaml:"rules,omitempty"`
+	Agents       *bool `yaml:"agents,omitempty"`
+	Skills       *bool `yaml:"skills,omitempty"`
+	Commands     *bool `yaml:"commands,omitempty"`
+	Tools        *bool `yaml:"tools,omitempty"`
+	Plugins      *bool `yaml:"plugins,omitempty"`
+	Themes       *bool `yaml:"themes,omitempty"`
+}
+
+// IsCategoryEnabled returns whether the named category is enabled.
+// nil receiver = all enabled. nil field = enabled.
+func (c *SettingsCategoryConfig) IsCategoryEnabled(category string) bool {
+	if c == nil {
+		return true
+	}
+	var field *bool
+	switch category {
+	case "settings":
+		field = c.Settings
+	case "instructions":
+		field = c.Instructions
+	case "rules":
+		field = c.Rules
+	case "agents":
+		field = c.Agents
+	case "skills":
+		field = c.Skills
+	case "commands":
+		field = c.Commands
+	case "tools":
+		field = c.Tools
+	case "plugins":
+		field = c.Plugins
+	case "themes":
+		field = c.Themes
+	default:
+		return true
+	}
+	if field == nil {
+		return true
+	}
+	return *field
 }
 
 // RuntimeConfig configures host runtime dependency handling.
@@ -386,6 +455,9 @@ type AgentOverride struct {
 
 	// MCP overrides the global MCP proxy settings for this agent.
 	MCP *MCPConfig `yaml:"mcp,omitempty"`
+
+	// SettingsImport overrides the global settings import for this agent.
+	SettingsImport *SettingsImportConfig `yaml:"settings_import,omitempty"`
 }
 
 // clampResources caps CPU and memory values to their maximums.
@@ -485,6 +557,9 @@ func MergeConfigs(global, local *Config) *Config {
 		SaveCredentials:     global.Auth.SaveCredentials,
 		SeedHostCredentials: global.Auth.SeedHostCredentials,
 	}
+
+	// SettingsImport: local can only disable (tighten), not enable.
+	result.SettingsImport = mergeSettingsImportConfig(global.SettingsImport, local.SettingsImport)
 
 	// Runtime: local overrides global when explicitly set.
 	result.Runtime = mergeRuntimeConfig(global.Runtime, local.Runtime)
@@ -640,6 +715,58 @@ func mergeRuntimeConfig(global, local RuntimeConfig) RuntimeConfig {
 		return RuntimeConfig{FirmwareDownload: local.FirmwareDownload}
 	}
 	return global
+}
+
+// mergeSettingsImportConfig merges local into global with tighten-only semantics.
+// Local can only disable settings import or individual categories, never enable them.
+func mergeSettingsImportConfig(global, local SettingsImportConfig) SettingsImportConfig {
+	result := global
+
+	// Local can only disable, not enable.
+	if local.Enabled != nil && !*local.Enabled {
+		result.Enabled = local.Enabled
+	}
+
+	// Merge categories: local can only disable individual categories.
+	if local.Categories != nil {
+		result.Categories = TightenSettingsCategories(result.Categories, local.Categories)
+	}
+
+	return result
+}
+
+// TightenSettingsCategories merges local categories into global with tighten-only
+// semantics. Local can only set categories to false (disable), never to true (enable).
+// Exported so the application layer can apply per-agent overrides with the same
+// security policy without reimplementing the tighten logic.
+func TightenSettingsCategories(global, local *SettingsCategoryConfig) *SettingsCategoryConfig {
+	if local == nil {
+		return global
+	}
+
+	// Start from global (or empty if nil).
+	var result SettingsCategoryConfig
+	if global != nil {
+		result = *global
+	}
+
+	tightenBool := func(dst **bool, src *bool) {
+		if src != nil && !*src {
+			*dst = src
+		}
+	}
+
+	tightenBool(&result.Settings, local.Settings)
+	tightenBool(&result.Instructions, local.Instructions)
+	tightenBool(&result.Rules, local.Rules)
+	tightenBool(&result.Agents, local.Agents)
+	tightenBool(&result.Skills, local.Skills)
+	tightenBool(&result.Commands, local.Commands)
+	tightenBool(&result.Tools, local.Tools)
+	tightenBool(&result.Plugins, local.Plugins)
+	tightenBool(&result.Themes, local.Themes)
+
+	return &result
 }
 
 // ToEgressHosts converts config host entries to domain egress hosts.

--- a/pkg/domain/config/config_test.go
+++ b/pkg/domain/config/config_test.go
@@ -975,6 +975,101 @@ func TestMergeConfigs_AgentOverridesMCPSecurityFieldsStripped(t *testing.T) {
 	assert.NotNil(t, global.Agents["claude-code"].MCP.Authz, "global input must not be mutated")
 }
 
+func TestMergeConfigs_SettingsImport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		global *Config
+		local  *Config
+		want   SettingsImportConfig
+	}{
+		{
+			name:   "both nil — defaults enabled",
+			global: &Config{},
+			local:  &Config{},
+			want:   SettingsImportConfig{},
+		},
+		{
+			name:   "global enabled, local disables — local wins",
+			global: &Config{SettingsImport: SettingsImportConfig{Enabled: boolPtr(true)}},
+			local:  &Config{SettingsImport: SettingsImportConfig{Enabled: boolPtr(false)}},
+			want:   SettingsImportConfig{Enabled: boolPtr(false)},
+		},
+		{
+			name:   "global nil, local enables — enable ignored (tighten only)",
+			global: &Config{},
+			local:  &Config{SettingsImport: SettingsImportConfig{Enabled: boolPtr(true)}},
+			want:   SettingsImportConfig{},
+		},
+		{
+			name:   "global disabled, local enables — global preserved",
+			global: &Config{SettingsImport: SettingsImportConfig{Enabled: boolPtr(false)}},
+			local:  &Config{SettingsImport: SettingsImportConfig{Enabled: boolPtr(true)}},
+			want:   SettingsImportConfig{Enabled: boolPtr(false)},
+		},
+		{
+			name:   "local disables skills category",
+			global: &Config{},
+			local:  &Config{SettingsImport: SettingsImportConfig{Categories: &SettingsCategoryConfig{Skills: boolPtr(false)}}},
+			want:   SettingsImportConfig{Categories: &SettingsCategoryConfig{Skills: boolPtr(false)}},
+		},
+		{
+			name: "local cannot re-enable disabled category",
+			global: &Config{SettingsImport: SettingsImportConfig{
+				Categories: &SettingsCategoryConfig{Skills: boolPtr(false)},
+			}},
+			local: &Config{SettingsImport: SettingsImportConfig{
+				Categories: &SettingsCategoryConfig{Skills: boolPtr(true)},
+			}},
+			want: SettingsImportConfig{Categories: &SettingsCategoryConfig{Skills: boolPtr(false)}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := MergeConfigs(tt.global, tt.local)
+			assert.Equal(t, tt.want, got.SettingsImport)
+		})
+	}
+}
+
+func TestSettingsImportConfig_IsEnabled(t *testing.T) {
+	t.Parallel()
+
+	// nil defaults to true
+	var cfg SettingsImportConfig
+	assert.True(t, cfg.IsEnabled())
+
+	// explicit true
+	cfg.Enabled = boolPtr(true)
+	assert.True(t, cfg.IsEnabled())
+
+	// explicit false
+	cfg.Enabled = boolPtr(false)
+	assert.False(t, cfg.IsEnabled())
+}
+
+func TestSettingsCategoryConfig_IsCategoryEnabled(t *testing.T) {
+	t.Parallel()
+
+	// nil receiver = all enabled
+	var c *SettingsCategoryConfig
+	assert.True(t, c.IsCategoryEnabled("settings"))
+	assert.True(t, c.IsCategoryEnabled("skills"))
+	assert.True(t, c.IsCategoryEnabled("unknown"))
+
+	// nil field = enabled
+	cfg := &SettingsCategoryConfig{}
+	assert.True(t, cfg.IsCategoryEnabled("settings"))
+
+	// explicit false
+	cfg.Skills = boolPtr(false)
+	assert.False(t, cfg.IsCategoryEnabled("skills"))
+	assert.True(t, cfg.IsCategoryEnabled("settings"))
+}
+
 func TestMerge_ResourceBounds(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/domain/settings/filter.go
+++ b/pkg/domain/settings/filter.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package settings
+
+// FilterEntries returns entries matching the predicate.
+func FilterEntries(entries []Entry, keep func(Entry) bool) []Entry {
+	var result []Entry
+	for _, e := range entries {
+		if keep(e) {
+			result = append(result, e)
+		}
+	}
+	return result
+}

--- a/pkg/domain/settings/filter_test.go
+++ b/pkg/domain/settings/filter_test.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterEntries(t *testing.T) {
+	t.Parallel()
+
+	skillsEntry := Entry{
+		Category:  "skills",
+		HostPath:  ".config/skills",
+		GuestPath: ".config/skills",
+		Kind:      KindDirectory,
+	}
+	settingsEntry := Entry{
+		Category:  "settings",
+		HostPath:  "settings.json",
+		GuestPath: "settings.json",
+		Kind:      KindFile,
+	}
+	rulesEntry := Entry{
+		Category:  "rules",
+		HostPath:  ".rules",
+		GuestPath: ".rules",
+		Kind:      KindDirectory,
+	}
+
+	allEntries := []Entry{skillsEntry, settingsEntry, rulesEntry}
+
+	tests := []struct {
+		name    string
+		entries []Entry
+		keep    func(Entry) bool
+		want    []Entry
+	}{
+		{
+			name:    "empty entries returns nil",
+			entries: nil,
+			keep:    func(_ Entry) bool { return true },
+			want:    nil,
+		},
+		{
+			name:    "empty slice returns nil",
+			entries: []Entry{},
+			keep:    func(_ Entry) bool { return true },
+			want:    nil,
+		},
+		{
+			name:    "keep all returns full list",
+			entries: allEntries,
+			keep:    func(_ Entry) bool { return true },
+			want:    allEntries,
+		},
+		{
+			name:    "keep none returns nil",
+			entries: allEntries,
+			keep:    func(_ Entry) bool { return false },
+			want:    nil,
+		},
+		{
+			name:    "filter by category keeps skills only",
+			entries: allEntries,
+			keep:    func(e Entry) bool { return e.Category == "skills" },
+			want:    []Entry{skillsEntry},
+		},
+		{
+			name:    "filter by multiple categories",
+			entries: allEntries,
+			keep: func(e Entry) bool {
+				return e.Category == "skills" || e.Category == "rules"
+			},
+			want: []Entry{skillsEntry, rulesEntry},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FilterEntries(tt.entries, tt.keep)
+
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestFilterEntries_PredicateReceivesCorrectValues(t *testing.T) {
+	t.Parallel()
+
+	entries := []Entry{
+		{
+			Category:  "settings",
+			HostPath:  "host/settings.json",
+			GuestPath: "guest/settings.json",
+			Kind:      KindMergeFile,
+			Optional:  true,
+			Format:    "json",
+		},
+		{
+			Category:  "skills",
+			HostPath:  "host/skills",
+			GuestPath: "guest/skills",
+			Kind:      KindDirectory,
+			Optional:  false,
+		},
+	}
+
+	var received []Entry
+	_ = FilterEntries(entries, func(e Entry) bool {
+		received = append(received, e)
+		return false
+	})
+
+	require.Len(t, received, 2)
+
+	// Verify the predicate received complete Entry values.
+	assert.Equal(t, "settings", received[0].Category)
+	assert.Equal(t, "host/settings.json", received[0].HostPath)
+	assert.Equal(t, "guest/settings.json", received[0].GuestPath)
+	assert.Equal(t, KindMergeFile, received[0].Kind)
+	assert.True(t, received[0].Optional)
+	assert.Equal(t, "json", received[0].Format)
+
+	assert.Equal(t, "skills", received[1].Category)
+	assert.Equal(t, "host/skills", received[1].HostPath)
+	assert.Equal(t, "guest/skills", received[1].GuestPath)
+	assert.Equal(t, KindDirectory, received[1].Kind)
+	assert.False(t, received[1].Optional)
+}

--- a/pkg/domain/settings/settings.go
+++ b/pkg/domain/settings/settings.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package settings defines domain types and interfaces for injecting
+// agent settings (rules, skills, commands, config files) from the host
+// into the guest VM rootfs.
+package settings
+
+// EntryKind classifies how a settings entry is injected.
+type EntryKind int
+
+const (
+	// KindFile copies a single file.
+	KindFile EntryKind = iota
+
+	// KindDirectory recursively copies a directory.
+	KindDirectory
+
+	// KindMergeFile parses a config file, filters fields, and merges
+	// the result into an existing guest file (preserving existing keys).
+	KindMergeFile
+)
+
+// FieldFilter defines an allowlist of top-level keys to extract from a config file.
+// Only keys in AllowKeys are copied. Security: denylist would leak new sensitive keys.
+type FieldFilter struct {
+	// AllowKeys lists top-level keys to include. Empty means copy all.
+	AllowKeys []string
+
+	// DenySubKeys maps allowed top-level keys to sub-key patterns to strip.
+	// Patterns support a leading wildcard: "*.apiKey" matches any map entry's
+	// "apiKey" field under that top-level key.
+	DenySubKeys map[string][]string
+}
+
+// Entry describes a single item to inject from host to guest.
+type Entry struct {
+	// Category groups entries for enable/disable control:
+	// "settings", "instructions", "rules", "agents", "skills",
+	// "commands", "tools", "plugins", "themes".
+	Category string
+
+	// HostPath is relative to $HOME on the host.
+	HostPath string
+
+	// GuestPath is relative to the guest home directory.
+	// Usually the same as HostPath.
+	GuestPath string
+
+	// Kind determines how the entry is processed.
+	Kind EntryKind
+
+	// Optional means skip silently if the source does not exist.
+	Optional bool
+
+	// Filter controls field-level filtering for KindMergeFile entries.
+	// Nil for KindFile and KindDirectory.
+	Filter *FieldFilter
+
+	// Format identifies the file format for KindMergeFile entries:
+	// "json", "toml", or "jsonc".
+	Format string
+}
+
+// Manifest is the per-agent list of settings to inject.
+type Manifest struct {
+	Entries []Entry
+}
+
+// Safety limits for settings injection.
+const (
+	// MaxFileSize is the maximum size per file (1 MiB).
+	MaxFileSize int64 = 1 << 20
+
+	// MaxTotalSize is the maximum aggregate size (50 MiB).
+	MaxTotalSize int64 = 50 << 20
+
+	// MaxFileCount is the maximum number of files to inject.
+	MaxFileCount = 500
+
+	// MaxDepth is the maximum directory nesting depth.
+	MaxDepth = 8
+)
+
+// Injector copies filtered settings from the host into the guest rootfs.
+type Injector interface {
+	// Inject processes each entry in the manifest, copying files from
+	// hostHomeDir into rootfsPath according to each entry's Kind.
+	Inject(rootfsPath, hostHomeDir string, manifest Manifest) error
+}

--- a/pkg/domain/vm/vm.go
+++ b/pkg/domain/vm/vm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stacklok/brood-box/pkg/domain/agent"
 	"github.com/stacklok/brood-box/pkg/domain/egress"
 	"github.com/stacklok/brood-box/pkg/domain/git"
+	"github.com/stacklok/brood-box/pkg/domain/settings"
 )
 
 // VMConfig holds the parameters needed to start a sandbox VM.
@@ -73,6 +74,9 @@ type VMConfig struct {
 	// TmpSizeMiB is the size of the /tmp tmpfs inside the guest in MiB.
 	// Zero uses the go-microvm default (256 MiB).
 	TmpSizeMiB uint32
+
+	// SettingsManifest declares agent settings to inject into the rootfs.
+	SettingsManifest *settings.Manifest
 }
 
 // HostService describes an HTTP service exposed from host to guest.

--- a/pkg/runtime/factory.go
+++ b/pkg/runtime/factory.go
@@ -17,6 +17,7 @@ import (
 	infradiff "github.com/stacklok/brood-box/internal/infra/diff"
 	infragit "github.com/stacklok/brood-box/internal/infra/git"
 	infrareview "github.com/stacklok/brood-box/internal/infra/review"
+	infrasettings "github.com/stacklok/brood-box/internal/infra/settings"
 	infrassh "github.com/stacklok/brood-box/internal/infra/ssh"
 	infravm "github.com/stacklok/brood-box/internal/infra/vm"
 	infraworkspace "github.com/stacklok/brood-box/internal/infra/workspace"
@@ -104,6 +105,10 @@ func NewDefaultSandboxDeps(opts DefaultSandboxDepsOpts) sandbox.SandboxDeps {
 	if opts.CacheDir != "" {
 		runnerOpts = append(runnerOpts, infravm.WithCacheDir(opts.CacheDir))
 	}
+
+	// Wire default settings injector so SDK consumers get settings injection.
+	settingsInjector := infrasettings.NewFSInjector(logger)
+	runnerOpts = append(runnerOpts, infravm.WithSettingsInjector(settingsInjector))
 
 	// Resolve snapshot base directory.
 	snapDir := opts.SnapshotDir

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stacklok/brood-box/pkg/domain/hostservice"
 	"github.com/stacklok/brood-box/pkg/domain/progress"
 	"github.com/stacklok/brood-box/pkg/domain/session"
+	"github.com/stacklok/brood-box/pkg/domain/settings"
 	"github.com/stacklok/brood-box/pkg/domain/snapshot"
 	domvm "github.com/stacklok/brood-box/pkg/domain/vm"
 	"github.com/stacklok/brood-box/pkg/domain/workspace"
@@ -109,6 +110,9 @@ type SandboxConfig struct {
 
 	// MCP configures the in-process MCP proxy.
 	MCP config.MCPConfig
+
+	// SettingsImport configures agent settings injection.
+	SettingsImport config.SettingsImportConfig
 }
 
 // SandboxDeps holds all dependencies for SandboxRunner.
@@ -258,6 +262,9 @@ func (s *SandboxRunner) Prepare(ctx context.Context, agentName string, opts RunO
 	}
 
 	ag = config.Merge(ag, override, cfg.Defaults)
+
+	// Resolve settings manifest: filter by enabled categories.
+	settingsManifest := s.resolveSettingsManifest(ag, cfg, agentName)
 
 	command, err := resolveCommand(ag.Command, opts.CommandOverride, opts.CommandArgs)
 	if err != nil {
@@ -447,23 +454,24 @@ func (s *SandboxRunner) Prepare(ctx context.Context, agentName string, opts RunO
 	s.observer.Start(progress.PhaseStartingVM, "Starting sandbox VM...")
 
 	vmCfg := domvm.VMConfig{
-		Name:            VMName(ag.Name, workspacePath, opts.SessionID),
-		AgentName:       ag.Name,
-		Image:           ag.Image,
-		CPUs:            ag.DefaultCPUs,
-		Memory:          ag.DefaultMemory,
-		SSHPort:         opts.SSHPort,
-		WorkspacePath:   workspacePath,
-		EnvVars:         envVars,
-		EgressPolicy:    egressPolicy,
-		HostServices:    hostServices,
-		MCPConfigFormat: ag.MCPConfigFormat,
-		GitIdentity:     gitIdentity,
-		HasGitToken:     hasGitToken,
-		SSHAgentForward: opts.SSHAgentForward,
-		CredentialPaths: ag.CredentialPaths,
-		LogLevel:        opts.LogLevel,
-		TmpSizeMiB:      ag.DefaultTmpSize,
+		Name:             VMName(ag.Name, workspacePath, opts.SessionID),
+		AgentName:        ag.Name,
+		Image:            ag.Image,
+		CPUs:             ag.DefaultCPUs,
+		Memory:           ag.DefaultMemory,
+		SSHPort:          opts.SSHPort,
+		WorkspacePath:    workspacePath,
+		EnvVars:          envVars,
+		EgressPolicy:     egressPolicy,
+		HostServices:     hostServices,
+		MCPConfigFormat:  ag.MCPConfigFormat,
+		GitIdentity:      gitIdentity,
+		HasGitToken:      hasGitToken,
+		SSHAgentForward:  opts.SSHAgentForward,
+		CredentialPaths:  ag.CredentialPaths,
+		LogLevel:         opts.LogLevel,
+		TmpSizeMiB:       ag.DefaultTmpSize,
+		SettingsManifest: settingsManifest,
 	}
 
 	sandboxVM, err := s.vmRunner.Start(ctx, vmCfg)
@@ -696,6 +704,48 @@ func isHexString(s string) bool {
 		}
 	}
 	return true
+}
+
+// resolveSettingsManifest returns the agent's settings manifest filtered by
+// enabled categories. Returns nil if settings import is disabled or the agent
+// has no manifest.
+func (s *SandboxRunner) resolveSettingsManifest(
+	ag agent.Agent, cfg *SandboxConfig, agentName string,
+) *settings.Manifest {
+	if ag.SettingsManifest == nil || len(ag.SettingsManifest.Entries) == 0 {
+		return nil
+	}
+
+	// Resolve settings import config: global + per-agent override.
+	// Uses the domain's TightenSettingsCategories to ensure the same
+	// tighten-only security policy as workspace config merging.
+	importCfg := cfg.SettingsImport
+	if override, ok := cfg.AgentOverrides[agentName]; ok && override.SettingsImport != nil {
+		// Per-agent override can only disable (tighten).
+		if override.SettingsImport.Enabled != nil && !*override.SettingsImport.Enabled {
+			importCfg.Enabled = override.SettingsImport.Enabled
+		}
+		if override.SettingsImport.Categories != nil {
+			importCfg.Categories = config.TightenSettingsCategories(
+				importCfg.Categories, override.SettingsImport.Categories,
+			)
+		}
+	}
+
+	if !importCfg.IsEnabled() {
+		return nil
+	}
+
+	// Filter entries by enabled categories.
+	filtered := settings.FilterEntries(ag.SettingsManifest.Entries, func(e settings.Entry) bool {
+		return importCfg.Categories.IsCategoryEnabled(e.Category)
+	})
+
+	if len(filtered) == 0 {
+		return nil
+	}
+
+	return &settings.Manifest{Entries: filtered}
 }
 
 // resolveMCPConfig returns the effective MCP configuration by merging


### PR DESCRIPTION
## Summary

- Implement declarative, per-agent settings injection framework that copies host agent settings (rules, skills, commands, instructions, config files) into the guest rootfs before boot
- Support all three agents: Claude Code (`~/.claude/`), Codex (`~/.codex/`), OpenCode (`~/.config/opencode/`)
- Fix MCP config hooks to deep-merge server maps instead of replacing (preserves user MCP servers alongside `sandbox-tools`)
- Add `--no-settings` CLI flag, `settings_import` config section, and tighten-only workspace merge semantics

### Architecture

Follows strict DDD — zero layer violations confirmed by review:

| Layer | New Files |
|---|---|
| Domain | `pkg/domain/settings/settings.go`, `filter.go` — pure types, interfaces, constants |
| Infrastructure | `internal/infra/settings/injector.go`, `jsonc.go` — FSInjector with O_NOFOLLOW, path containment, field filtering |
| Infrastructure | `internal/infra/vm/settingshook.go` — rootfs hook (mirrors `credentialhook.go`) |
| Application | `pkg/sandbox/sandbox.go` — `resolveSettingsManifest` with category filtering |
| Composition | `cmd/bbox/main.go`, `pkg/runtime/factory.go` — wiring |

### Security

- **Allowlist-only field filtering** for MergeFile entries (deny-by-default for new config keys)
- **DenySubKeys** strip secrets from MCP server configs (`*.env`, `*.headers`, `*.token`, etc.)
- **O_NOFOLLOW** reads prevent TOCTOU symlink attacks (matching credential store pattern)
- **Source + destination path containment** with `filepath.EvalSymlinks`
- **Tighten-only merge** from workspace `.broodbox.yaml` (can only disable, never enable)
- **Size limits**: 1 MiB/file, 50 MiB aggregate, 500 files, 8 depth

### Hook Ordering

```
1. SSH keys + init binary + env + git config
2. InjectCredentials  (creates base config files)
3. InjectSettings     (merges user settings on top)   ← NEW
4. InjectMCPConfig    (deep-merges sandbox-tools)
```

### Adding a Future Agent

Only requires populating `SettingsManifest` in `registry.go` — no new code paths.

## Test plan

- [x] `task fmt` — clean
- [x] `task lint` — 0 issues
- [x] `task test` — 26/26 packages pass (with race detector)
- [x] New tests: `filter_test.go`, `settingshook_test.go`, `injector_test.go` (file/dir/merge/JSONC/safety limits), config merge tests, MCP deep-merge edge cases
- [ ] Manual: `bbox claude-code` with `~/.claude/settings.json`, rules/, skills/ → verify files in guest
- [ ] Manual: `bbox claude-code --no-settings` → verify no settings injected
- [ ] Manual: `bbox codex` with `~/.codex/config.toml` containing `[auth]` → verify auth stripped
- [ ] Manual: Verify MCP servers from host `.claude.json` preserved alongside `sandbox-tools`

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)
