### PR TITLE
Add `bbox config init` command

### DIFF
--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -188,6 +188,7 @@ Example:
 	// Add subcommands.
 	cmd.AddCommand(listCmd())
 	cmd.AddCommand(authCmd())
+	cmd.AddCommand(configCmd())
 
 	return cmd
 }
@@ -269,6 +270,43 @@ func authClearCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func configCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Manage Brood Box configuration",
+	}
+	cmd.AddCommand(configInitCmd())
+	return cmd
+}
+
+func configInitCmd() *cobra.Command {
+	var cfgPath string
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Create a default config file with all options documented",
+		Long: `Creates ~/.config/broodbox/config.yaml (or the path given by --config)
+with all configuration options documented as YAML comments.
+
+If the file already exists the command fails unless --force is passed.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			path := cfgPath
+			if path == "" {
+				path = infraconfig.NewLoader("").Path()
+			}
+			if err := infraconfig.WriteDefault(path, force); err != nil {
+				return err
+			}
+			fmt.Printf("Config written to %s\n", path)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cfgPath, "config", "", "Config file path (default: ~/.config/broodbox/config.yaml)")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite the config file if it already exists")
+	return cmd
 }
 
 type runFlags struct {

--- a/internal/infra/config/writer.go
+++ b/internal/infra/config/writer.go
@@ -22,7 +22,8 @@ var defaultConfigTemplate = `# Brood Box configuration
 #   # Number of vCPUs (0 = agent default).
 #   cpus: 0
 #
-#   # RAM in MiB (0 = agent default).
+#   # RAM for the VM. Accepts human-readable values like "4g" or "512m".
+#   # Bare integers are treated as MiB. Zero uses the agent default.
 #   memory: 0
 #
 #   # Size of /tmp tmpfs inside the VM. Accepts human-readable values
@@ -139,7 +140,7 @@ var defaultConfigTemplate = `# Brood Box configuration
 #   #   # Override vCPU count for this agent.
 #   #   cpus: 0
 #   #
-#   #   # Override RAM in MiB for this agent.
+#   #   # Override RAM for this agent (e.g. "4g", "512m").
 #   #   memory: 0
 #   #
 #   #   # Override /tmp tmpfs size for this agent (e.g. "512m", "2g").
@@ -153,10 +154,11 @@ var defaultConfigTemplate = `# Brood Box configuration
 #   #   allow_hosts: []
 #   #
 #   #   # Override MCP proxy settings for this agent.
+#   #   # Only enabled (gate) and authz (tighten-only) are supported.
 #   #   mcp:
 #   #     enabled: true
-#   #     group: "default"
-#   #     port: 4483
+#   #     authz:
+#   #       profile: "full-access"
 `
 
 // WriteDefault writes the default config template to the given path.
@@ -181,6 +183,13 @@ func WriteDefault(path string, force bool) error {
 
 	if err := os.WriteFile(path, []byte(defaultConfigTemplate), 0o600); err != nil {
 		return fmt.Errorf("writing config file: %w", err)
+	}
+
+	// WriteFile only sets permissions on creation. When overwriting an
+	// existing file (--force) the old permissions remain. Explicitly
+	// chmod to ensure 0600 regardless of prior state.
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("setting config file permissions: %w", err)
 	}
 
 	return nil

--- a/internal/infra/config/writer.go
+++ b/internal/infra/config/writer.go
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// defaultConfigTemplate is a fully commented YAML template documenting every
+// Config field. All values are commented out so the file is safe to ship as-is.
+var defaultConfigTemplate = `# Brood Box configuration
+# All values below are commented out and show their defaults.
+# Uncomment and modify the settings you want to change.
+
+# Default VM resource limits applied to all agents unless overridden.
+# defaults:
+#   # Number of vCPUs (0 = agent default).
+#   cpus: 0
+#
+#   # RAM in MiB (0 = agent default).
+#   memory: 0
+#
+#   # Size of /tmp tmpfs inside the VM. Accepts human-readable values
+#   # like "512m" or "2g". Zero uses the go-microvm default (256 MiB).
+#   tmp_size: 0
+#
+#   # Default egress restriction level: permissive, standard, locked.
+#   # "permissive" allows all outbound traffic (no restrictions).
+#   # "standard" allows the agent's LLM provider plus common dev infra.
+#   # "locked" allows only the agent's LLM provider.
+#   egress_profile: ""
+
+# Workspace snapshot isolation and review behavior.
+# Snapshot isolation is always active. Use review.enabled or --review
+# to interactively approve or reject each changed file.
+# review:
+#   # Enable interactive per-file review of workspace changes.
+#   # NOTE: This setting is ignored in per-workspace .broodbox.yaml
+#   # for security — use --review flag or this global config only.
+#   enabled: false
+#
+#   # Additional gitignore-style patterns to exclude from the workspace
+#   # snapshot diff. Security patterns (.env*, *.pem, etc.) are always
+#   # excluded and cannot be overridden.
+#   exclude_patterns: []
+#   # exclude_patterns:
+#   #   - "*.log"
+#   #   - "tmp/"
+
+# Egress networking configuration.
+# network:
+#   # Additional egress hosts to allow beyond the profile defaults.
+#   # Each entry specifies a DNS hostname (no IP addresses).
+#   allow_hosts: []
+#   # allow_hosts:
+#   #   - name: custom-api.example.com
+#   #     ports: [443]
+#   #     protocol: 6  # TCP
+
+# MCP (Model Context Protocol) proxy configuration.
+# The MCP proxy discovers servers from ToolHive and makes them
+# available to the agent inside the VM.
+# mcp:
+#   # Enable or disable the MCP proxy (default: true).
+#   enabled: true
+#
+#   # ToolHive group to discover MCP servers from.
+#   group: "default"
+#
+#   # TCP port for the MCP proxy on the VM gateway.
+#   port: 4483
+#
+#   # Authorization profile: full-access, observe, safe-tools, custom.
+#   # "full-access" — no restrictions (default).
+#   # "observe" — list + read tools/prompts/resources only.
+#   # "safe-tools" — observe + non-destructive closed-world tools.
+#   # "custom" — Cedar policies from mcp.config or --mcp-config.
+#   # authz:
+#   #   profile: "full-access"
+#
+#   # Inline MCP config for Cedar authorization policies and tool
+#   # aggregation settings. Can also be loaded from a file via --mcp-config.
+#   # NOTE: mcp.config is NOT merged from per-workspace .broodbox.yaml
+#   # for security — untrusted repos must not inject Cedar policies.
+#   # config:
+#   #   authz:
+#   #     policies:
+#   #       - 'permit(principal, action == Action::"list_tools", resource);'
+#   #   aggregation:
+#   #     conflict_resolution: "prefix"  # prefix, priority, or manual
+#   #     prefix_format: ""
+#   #     priority_order: []
+#   #     exclude_all_tools: false
+#   #     tools: []
+
+# Git identity and authentication forwarding into the sandbox VM.
+# git:
+#   # Forward GITHUB_TOKEN/GH_TOKEN into the VM (default: true).
+#   forward_token: true
+#
+#   # Enable SSH agent forwarding into the VM (default: true).
+#   forward_ssh_agent: true
+
+# Credential persistence between sessions.
+# auth:
+#   # Save agent credentials between sessions (default: true).
+#   save_credentials: true
+#
+#   # Seed agent credentials from host (e.g. macOS Keychain) into the
+#   # VM before the agent starts (default: false).
+#   seed_host_credentials: false
+
+# Host runtime dependency configuration.
+# runtime:
+#   # Download libkrunfw firmware at runtime (default: true).
+#   # Set to false to use system-installed libkrunfw only.
+#   firmware_download: true
+
+# Per-agent configuration overrides. Keys are agent names
+# (e.g. claude-code, codex, opencode, or custom agent names).
+# agents:
+#   # claude-code:
+#   #   # Override the OCI image reference.
+#   #   image: "ghcr.io/stacklok/brood-box/claude-code:latest"
+#   #
+#   #   # Override the entrypoint command.
+#   #   command: ["claude-code"]
+#   #
+#   #   # Override environment variable forwarding patterns.
+#   #   env_forward:
+#   #     - ANTHROPIC_API_KEY
+#   #     - "CLAUDE_*"
+#   #
+#   #   # Override vCPU count for this agent.
+#   #   cpus: 0
+#   #
+#   #   # Override RAM in MiB for this agent.
+#   #   memory: 0
+#   #
+#   #   # Override /tmp tmpfs size for this agent (e.g. "512m", "2g").
+#   #   tmp_size: 0
+#   #
+#   #   # Override egress profile for this agent.
+#   #   # Can only tighten (not widen) the agent's built-in profile.
+#   #   egress_profile: ""
+#   #
+#   #   # Additional egress hosts for this agent.
+#   #   allow_hosts: []
+#   #
+#   #   # Override MCP proxy settings for this agent.
+#   #   mcp:
+#   #     enabled: true
+#   #     group: "default"
+#   #     port: 4483
+`
+
+// WriteDefault writes the default config template to the given path.
+// Parent directories are created with mode 0o700. The file is written
+// with mode 0o600. Returns an error if the file already exists and
+// force is false.
+func WriteDefault(path string, force bool) error {
+	if !force {
+		_, err := os.Stat(path)
+		if err == nil {
+			return fmt.Errorf("config file already exists: %s (use --force to overwrite)", path)
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("checking config file: %w", err)
+		}
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, []byte(defaultConfigTemplate), 0o600); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/infra/config/writer_test.go
+++ b/internal/infra/config/writer_test.go
@@ -16,11 +16,11 @@ func TestWriteDefault(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		setup     func(t *testing.T, dir string) string
-		force     bool
-		wantErr   string
-		assertFn  func(t *testing.T, path string)
+		name     string
+		setup    func(t *testing.T, dir string) string
+		force    bool
+		wantErr  string
+		assertFn func(t *testing.T, path string)
 	}{
 		{
 			name: "creates file when it does not exist",
@@ -85,6 +85,12 @@ func TestWriteDefault(t *testing.T) {
 				require.NoError(t, err)
 				assert.Contains(t, string(data), "# Brood Box")
 				assert.NotContains(t, string(data), "old content")
+
+				// Verify permissions are reset to 0600 even though
+				// the original file was 0644.
+				info, err := os.Stat(path)
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 			},
 		},
 		{
@@ -119,7 +125,8 @@ func TestWriteDefault(t *testing.T) {
 				content := string(data)
 				for _, section := range []string{
 					"defaults:", "review:", "network:",
-					"mcp:", "git:", "auth:", "runtime:", "agents:",
+					"mcp:", "authz:", "config:",
+					"git:", "auth:", "runtime:", "agents:",
 				} {
 					assert.Contains(t, content, section,
 						"template should contain section %q", section)

--- a/internal/infra/config/writer_test.go
+++ b/internal/infra/config/writer_test.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, dir string) string
+		force     bool
+		wantErr   string
+		assertFn  func(t *testing.T, path string)
+	}{
+		{
+			name: "creates file when it does not exist",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				return filepath.Join(dir, "config.yaml")
+			},
+			wantErr: "",
+			assertFn: func(t *testing.T, path string) {
+				t.Helper()
+				data, err := os.ReadFile(path)
+				require.NoError(t, err)
+				assert.Contains(t, string(data), "# Brood Box")
+
+				info, err := os.Stat(path)
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+			},
+		},
+		{
+			name: "creates parent directories",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				return filepath.Join(dir, "a", "b", "c", "config.yaml")
+			},
+			wantErr: "",
+			assertFn: func(t *testing.T, path string) {
+				t.Helper()
+				_, err := os.Stat(path)
+				require.NoError(t, err)
+
+				parentDir := filepath.Dir(path)
+				info, err := os.Stat(parentDir)
+				require.NoError(t, err)
+				assert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+			},
+		},
+		{
+			name: "errors when file exists and force is false",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				path := filepath.Join(dir, "config.yaml")
+				require.NoError(t, os.WriteFile(path, []byte("existing"), 0o644))
+				return path
+			},
+			force:   false,
+			wantErr: "already exists",
+		},
+		{
+			name: "overwrites when file exists and force is true",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				path := filepath.Join(dir, "config.yaml")
+				require.NoError(t, os.WriteFile(path, []byte("old content"), 0o644))
+				return path
+			},
+			force:   true,
+			wantErr: "",
+			assertFn: func(t *testing.T, path string) {
+				t.Helper()
+				data, err := os.ReadFile(path)
+				require.NoError(t, err)
+				assert.Contains(t, string(data), "# Brood Box")
+				assert.NotContains(t, string(data), "old content")
+			},
+		},
+		{
+			name: "template is valid YAML that parses to zero-value Config",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				return filepath.Join(dir, "config.yaml")
+			},
+			wantErr: "",
+			assertFn: func(t *testing.T, path string) {
+				t.Helper()
+				loader := NewLoader(path)
+				cfg, err := loader.Load()
+				require.NoError(t, err)
+				assert.Zero(t, cfg.Defaults.CPUs)
+				assert.Zero(t, cfg.Defaults.Memory)
+				assert.Nil(t, cfg.Agents)
+				assert.Nil(t, cfg.Review.Enabled)
+			},
+		},
+		{
+			name: "template contains all config sections",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				return filepath.Join(dir, "config.yaml")
+			},
+			wantErr: "",
+			assertFn: func(t *testing.T, path string) {
+				t.Helper()
+				data, err := os.ReadFile(path)
+				require.NoError(t, err)
+				content := string(data)
+				for _, section := range []string{
+					"defaults:", "review:", "network:",
+					"mcp:", "git:", "auth:", "runtime:", "agents:",
+				} {
+					assert.Contains(t, content, section,
+						"template should contain section %q", section)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := tt.setup(t, dir)
+
+			err := WriteDefault(path, tt.force)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.assertFn != nil {
+				tt.assertFn(t, path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `bbox config init` subcommand that generates `~/.config/broodbox/config.yaml` with every configuration option documented as YAML comments
- All values are commented out so the file is safe to ship as-is and parses to a zero-value config
- Respects `--config` for a custom path and `--force` to overwrite an existing file
- Update CLAUDE.md with guidance to keep the template in sync when config fields change

## Test plan

- [x] Unit tests cover: file creation, parent directory creation, existing-file guard, `--force` overwrite, template parses to zero-value `Config`, all config sections present
- [ ] Manual: `task build && ./bin/bbox config init` writes the file, inspect contents
- [ ] Manual: re-run without `--force` → errors; re-run with `--force` → overwrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)