### PR TITLE
Fix git SSH push inside guest VMs

### DIFF
--- a/internal/infra/git/identity.go
+++ b/internal/infra/git/identity.go
@@ -29,8 +29,9 @@ func NewHostIdentityProvider(homeDir string) *HostIdentityProvider {
 	return &HostIdentityProvider{homeDir: homeDir}
 }
 
-// GetIdentity returns the git user identity from the host's ~/.gitconfig.
-// Returns a zero Identity (not an error) if no .gitconfig exists.
+// GetIdentity returns the git user identity and URL rewrite rules from
+// the host's ~/.gitconfig. Returns a zero Identity (not an error) if
+// no .gitconfig exists.
 func (p *HostIdentityProvider) GetIdentity() (domaingit.Identity, error) {
 	home := p.homeDir
 	if home == "" {
@@ -49,7 +50,9 @@ func (p *HostIdentityProvider) GetIdentity() (domaingit.Identity, error) {
 		return domaingit.Identity{}, fmt.Errorf("reading .gitconfig: %w", err)
 	}
 
-	return parseUserIdentity(string(data)), nil
+	id := parseUserIdentity(string(data))
+	id.URLRewrites = parseURLRewrites(string(data))
+	return id, nil
 }
 
 // parseUserIdentity extracts the user.name and user.email values from
@@ -90,6 +93,48 @@ func parseUserIdentity(content string) domaingit.Identity {
 	}
 
 	return id
+}
+
+// parseURLRewrites extracts [url "base"].insteadOf rules from a git
+// config file. These rules tell git to replace URL prefixes when
+// connecting to remotes (e.g. rewriting HTTPS to SSH for authentication).
+func parseURLRewrites(content string) []domaingit.URLRewrite {
+	var rewrites []domaingit.URLRewrite
+	var currentBase string
+
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "[") {
+			section := parseSectionName(trimmed)
+			if section == "url" {
+				currentBase = parseSubsection(trimmed)
+			} else {
+				currentBase = ""
+			}
+			continue
+		}
+
+		if currentBase == "" {
+			continue
+		}
+
+		key, value, ok := parseKeyValue(trimmed)
+		if !ok {
+			continue
+		}
+
+		if strings.ToLower(key) == "insteadof" && value != "" {
+			rewrites = append(rewrites, domaingit.URLRewrite{
+				Base:      currentBase,
+				InsteadOf: value,
+			})
+		}
+	}
+
+	return rewrites
 }
 
 // parseKeyValue splits a git config line into key and value.

--- a/internal/infra/git/identity_test.go
+++ b/internal/infra/git/identity_test.go
@@ -91,6 +91,85 @@ func TestHostIdentityProvider(t *testing.T) {
 	}
 }
 
+func TestHostIdentityProvider_URLRewrites(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	err := os.WriteFile(filepath.Join(homeDir, ".gitconfig"), []byte(`[user]
+	name = Alice
+	email = alice@example.com
+[url "git@github.com:"]
+	insteadOf = https://github.com/
+[url "git@gitlab.com:"]
+	insteadOf = https://gitlab.com/
+`), 0o644)
+	require.NoError(t, err)
+
+	provider := NewHostIdentityProvider(homeDir)
+	id, err := provider.GetIdentity()
+	require.NoError(t, err)
+
+	assert.Equal(t, "Alice", id.Name)
+	assert.Equal(t, "alice@example.com", id.Email)
+	require.Len(t, id.URLRewrites, 2)
+	assert.Equal(t, "git@github.com:", id.URLRewrites[0].Base)
+	assert.Equal(t, "https://github.com/", id.URLRewrites[0].InsteadOf)
+	assert.Equal(t, "git@gitlab.com:", id.URLRewrites[1].Base)
+	assert.Equal(t, "https://gitlab.com/", id.URLRewrites[1].InsteadOf)
+}
+
+func TestParseURLRewrites(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  []domaingit.URLRewrite
+	}{
+		{
+			name:  "no rewrites",
+			input: "[core]\n\tautocrlf = input\n",
+			want:  nil,
+		},
+		{
+			name:  "single rewrite",
+			input: "[url \"git@github.com:\"]\n\tinsteadOf = https://github.com/\n",
+			want: []domaingit.URLRewrite{
+				{Base: "git@github.com:", InsteadOf: "https://github.com/"},
+			},
+		},
+		{
+			name: "multiple rewrites",
+			input: "[url \"git@github.com:\"]\n\tinsteadOf = https://github.com/\n" +
+				"[url \"git@gitlab.com:\"]\n\tinsteadOf = https://gitlab.com/\n",
+			want: []domaingit.URLRewrite{
+				{Base: "git@github.com:", InsteadOf: "https://github.com/"},
+				{Base: "git@gitlab.com:", InsteadOf: "https://gitlab.com/"},
+			},
+		},
+		{
+			name:  "non-url section ignored",
+			input: "[remote \"origin\"]\n\turl = https://github.com/org/repo.git\n",
+			want:  nil,
+		},
+		{
+			name:  "case insensitive insteadOf key",
+			input: "[url \"git@github.com:\"]\n\tInsteadOf = https://github.com/\n",
+			want: []domaingit.URLRewrite{
+				{Base: "git@github.com:", InsteadOf: "https://github.com/"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseURLRewrites(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestParseUserIdentity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infra/git/sanitizer.go
+++ b/internal/infra/git/sanitizer.go
@@ -528,8 +528,14 @@ func sanitizeURL(value string) string {
 	u, err := url.Parse(trimmed)
 	if err == nil && u.Scheme != "" {
 		if u.User != nil {
-			u.User = nil
-			return u.String()
+			_, hasPassword := u.User.Password()
+			if hasPassword {
+				// Strip embedded credentials (user:token@host).
+				u.User = nil
+				return u.String()
+			}
+			// Username-only (e.g. ssh://git@host) — SSH key auth, not a secret.
+			return trimmed
 		}
 		return trimmed
 	}

--- a/internal/infra/git/sanitizer_test.go
+++ b/internal/infra/git/sanitizer_test.go
@@ -138,6 +138,30 @@ func TestSanitizeConfig(t *testing.T) {
 			}, "\n"),
 		},
 		{
+			name: "ssh scheme URL with username preserved",
+			input: strings.Join([]string{
+				`[remote "origin"]`,
+				"\turl = ssh://git@github.com/org/repo.git",
+				"\tfetch = +refs/heads/*:refs/remotes/origin/*",
+			}, "\n"),
+			expected: strings.Join([]string{
+				`[remote "origin"]`,
+				"\turl = ssh://git@github.com/org/repo.git",
+				"\tfetch = +refs/heads/*:refs/remotes/origin/*",
+			}, "\n"),
+		},
+		{
+			name: "ssh scheme URL with password stripped",
+			input: strings.Join([]string{
+				`[remote "origin"]`,
+				"\turl = ssh://deploy:token@github.com/org/repo.git",
+			}, "\n"),
+			expected: strings.Join([]string{
+				`[remote "origin"]`,
+				"\turl = ssh://github.com/org/repo.git",
+			}, "\n"),
+		},
+		{
 			name: "malformed HTTPS URL with credentials fail closed",
 			input: strings.Join([]string{
 				`[remote "origin"]`,

--- a/internal/infra/vm/gitconfig.go
+++ b/internal/infra/vm/gitconfig.go
@@ -97,6 +97,21 @@ func writeGitConfig(rootfsPath string, identity domaingit.Identity, hasGitToken 
 		b.WriteString("\thelper = /usr/local/bin/git-credential-bbox\n")
 	}
 
+	// Write URL rewrite rules from the host's global gitconfig.
+	// These are [url "base"].insteadOf directives that git uses to
+	// rewrite remote URLs (e.g. HTTPS → SSH for push authentication).
+	// Without them, repos whose .git/config uses HTTPS URLs with a
+	// host-side insteadOf rewrite to SSH will not use SSH agent
+	// forwarding inside the guest.
+	for _, rw := range identity.URLRewrites {
+		base := sanitizeGitValue(rw.Base)
+		insteadOf := sanitizeGitValue(rw.InsteadOf)
+		if base != "" && insteadOf != "" {
+			b.WriteString("[url \"" + base + "\"]\n")
+			b.WriteString("\tinsteadOf = " + insteadOf + "\n")
+		}
+	}
+
 	// Always mark /workspace as safe to prevent "dubious ownership" errors.
 	// The host workspace is mounted at /workspace with a different UID than
 	// the sandbox user — git 2.36+ rejects this without safe.directory.

--- a/internal/infra/vm/knownhosts.go
+++ b/internal/infra/vm/knownhosts.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/stacklok/go-microvm/image"
+)
+
+// knownHostsContent contains well-known SSH host keys for major Git
+// hosting providers. These are public keys published by the providers
+// and are NOT secrets — they are the same keys any SSH client receives
+// on first connection and stores in ~/.ssh/known_hosts.
+//
+// Without these keys, git push/pull over SSH inside the guest VM fails
+// with "Host key verification failed" because the ephemeral guest has
+// no pre-existing known_hosts file and the SSH client cannot
+// interactively prompt the user through the agent's PTY.
+//
+// Each provider publishes three key types (ed25519, ecdsa, rsa) to
+// support hosts with different SSH client configurations. All three
+// are included so the guest SSH client can negotiate with whichever
+// algorithm the server prefers.
+//
+// To update these keys, run:
+//
+//	ssh-keyscan -t ed25519,ecdsa,rsa github.com gitlab.com bitbucket.org
+//
+// and cross-reference with the official documentation:
+//   - GitHub:    https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+//   - GitLab:    https://docs.gitlab.com/ee/user/gitlab_com/#ssh-host-keys-fingerprints
+//   - Bitbucket: https://bitbucket.org/blog/ssh-host-key-changes
+//
+// Last verified: 2026-03-17 via ssh-keyscan and official documentation.
+const knownHostsContent = `github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
+gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
+gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
+bitbucket.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIazEu89wgQZ4bqs3d63QSMzYVa0MuJ2e2gKTKqu+UUO
+bitbucket.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPIQmuzMBuKdWeF4+a2sjSSpBK0iqitSQ+5BM9KhpexuGt20JpTVM7u5BDZngncgrqDMbWdxMWWOGtZ9UgbqgZE=
+bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDQeJzhupRu0u0cdegZIa8e86EG2qOCsIsD1Xw0xSeiPDlCr7kq97NLmMbpKTX6Esc30NuoqEEHCuc7yWtwp8dI76EEEB1VqY9QJq6vk+aySyboD5QF61I/1WeTwu+deCbgKMGbUijeXhtfbxSxm6JwGrXrhBdofTsbKRUsrN1WoNgUa8uqN1Vx6WAJw1JHPhglEGGHea6QICwJOAr/6mrui/oB7pkaWKHj3z7d1IC4KWLtY47elvjbaTlkN04Kc/5LFEirorGYVbt15kAUlqGM65pk6ZBxtaO3+30LVlORZkxOh+LKL/BvbZ/iRNhItLqNyieoQj/uh/7Iv4uyH/cV/0b4WDSd3DptigWq84lJubb9t/DnZlrJazxyDCulTmKdOR7vs9gMTo+uoIrPSb8ScTtvw65+odKAlBj59dhnVp9zd7QUojOpXlL62Aw56U4oO+FALuevvMjiWeavKhJqlR7i5n9srYcrNV7ttmDw7kf/97P5zauIhxcjX+xHv4M=
+`
+
+// InjectSSHKnownHosts returns a RootFS hook that writes well-known SSH
+// host keys for major Git hosting providers into the sandbox user's
+// ~/.ssh/known_hosts file.
+//
+// This is required for git push/pull over SSH to work inside the guest
+// VM. Without it, the SSH client rejects connections to GitHub, GitLab,
+// and Bitbucket because their host keys are unknown. The guest VM's
+// home directory is ephemeral (overlayfs on tmpfs), so even if a user
+// accepts a host key interactively, it is lost on the next boot.
+//
+// The hook creates ~/.ssh/ (mode 0700) if it doesn't exist and writes
+// known_hosts with mode 0600, both owned by the sandbox user (1000:1000).
+// The base image already creates ~/.ssh/ in the Dockerfile, but the
+// hook is idempotent and handles both cases.
+func InjectSSHKnownHosts(chown ChownFunc) func(string, *image.OCIConfig) error {
+	return func(rootfsPath string, _ *image.OCIConfig) error {
+		sshDir := filepath.Join(rootfsPath, sandboxHome, ".ssh")
+		if err := os.MkdirAll(sshDir, 0o700); err != nil {
+			return fmt.Errorf("creating .ssh dir: %w", err)
+		}
+		if err := chown(sshDir, sandboxUID, sandboxGID); err != nil {
+			return fmt.Errorf("chowning .ssh dir: %w", err)
+		}
+
+		knownHostsPath := filepath.Join(sshDir, "known_hosts")
+		if err := os.WriteFile(knownHostsPath, []byte(knownHostsContent), 0o600); err != nil {
+			return fmt.Errorf("writing known_hosts: %w", err)
+		}
+		return chown(knownHostsPath, sandboxUID, sandboxGID)
+	}
+}

--- a/internal/infra/vm/knownhosts_test.go
+++ b/internal/infra/vm/knownhosts_test.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectSSHKnownHosts_WritesFile(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hook := InjectSSHKnownHosts(nopChown)
+	require.NoError(t, hook(rootfs, nil))
+
+	path := filepath.Join(rootfs, sandboxHome, ".ssh", "known_hosts")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+}
+
+func TestInjectSSHKnownHosts_FilePermissions(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hook := InjectSSHKnownHosts(nopChown)
+	require.NoError(t, hook(rootfs, nil))
+
+	path := filepath.Join(rootfs, sandboxHome, ".ssh", "known_hosts")
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestInjectSSHKnownHosts_SSHDirPermissions(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hook := InjectSSHKnownHosts(nopChown)
+	require.NoError(t, hook(rootfs, nil))
+
+	sshDir := filepath.Join(rootfs, sandboxHome, ".ssh")
+	info, err := os.Stat(sshDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+}
+
+func TestInjectSSHKnownHosts_ContainsExpectedHosts(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hook := InjectSSHKnownHosts(nopChown)
+	require.NoError(t, hook(rootfs, nil))
+
+	path := filepath.Join(rootfs, sandboxHome, ".ssh", "known_hosts")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	content := string(data)
+	for _, host := range []string{"github.com", "gitlab.com", "bitbucket.org"} {
+		assert.Contains(t, content, host, "known_hosts should contain %s", host)
+	}
+}
+
+func TestInjectSSHKnownHosts_ContainsExpectedKeyTypes(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hook := InjectSSHKnownHosts(nopChown)
+	require.NoError(t, hook(rootfs, nil))
+
+	path := filepath.Join(rootfs, sandboxHome, ".ssh", "known_hosts")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	content := string(data)
+	for _, keyType := range []string{"ssh-ed25519", "ecdsa-sha2-nistp256", "ssh-rsa"} {
+		assert.True(t,
+			strings.Contains(content, "github.com "+keyType),
+			"known_hosts should contain github.com %s key", keyType,
+		)
+	}
+}
+
+func TestInjectSSHKnownHosts_ChownCalled(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	var calls []chownCall
+	recorder := func(path string, uid, gid int) error {
+		calls = append(calls, chownCall{Path: path, UID: uid, GID: gid})
+		return nil
+	}
+
+	hook := InjectSSHKnownHosts(recorder)
+	require.NoError(t, hook(rootfs, nil))
+
+	// Should chown both .ssh dir and known_hosts file.
+	require.Len(t, calls, 2)
+	assert.Equal(t, sandboxUID, calls[0].UID)
+	assert.Equal(t, sandboxGID, calls[0].GID)
+	assert.True(t, strings.HasSuffix(calls[0].Path, ".ssh"))
+	assert.Equal(t, sandboxUID, calls[1].UID)
+	assert.Equal(t, sandboxGID, calls[1].GID)
+	assert.True(t, strings.HasSuffix(calls[1].Path, "known_hosts"))
+}
+
+// nopChown is a no-op ChownFunc for tests that don't need ownership tracking.
+func nopChown(_ string, _, _ int) error { return nil }

--- a/internal/infra/vm/runner.go
+++ b/internal/infra/vm/runner.go
@@ -171,6 +171,7 @@ func (r *MicroVMRunner) Start(ctx context.Context, cfg domvm.VMConfig) (domvm.VM
 			InjectInitBinary(),
 			hooks.InjectEnvFile("/etc/sandbox-env", cfg.EnvVars),
 			InjectGitConfig(cfg.GitIdentity, cfg.HasGitToken, bestEffortLchown),
+			InjectSSHKnownHosts(bestEffortLchown),
 		),
 		microvm.WithInitOverride("/bbox-init"),
 		microvm.WithPostBoot(func(ctx context.Context, _ *microvm.VM) error {

--- a/pkg/domain/git/identity.go
+++ b/pkg/domain/git/identity.go
@@ -5,10 +5,27 @@
 // and environment variable forwarding.
 package git
 
-// Identity holds the git user identity (name and email).
+// Identity holds the git user identity (name and email) and any URL
+// rewrite rules from the host's git configuration.
 type Identity struct {
 	Name  string
 	Email string
+
+	// URLRewrites are [url "..."].insteadOf rules from the host's
+	// global gitconfig. These allow the guest to resolve HTTPS remote
+	// URLs to SSH (or vice versa) the same way the host does.
+	// Common example: [url "git@github.com:"].insteadOf = https://github.com/
+	URLRewrites []URLRewrite
+}
+
+// URLRewrite represents a git [url "<base>"].insteadOf rewrite rule.
+// When git encounters a remote URL starting with InsteadOf, it replaces
+// that prefix with Base before connecting.
+type URLRewrite struct {
+	// Base is the replacement URL prefix (the subsection of [url "..."]).
+	Base string
+	// InsteadOf is the URL prefix to match and replace.
+	InsteadOf string
 }
 
 // IsComplete returns true if both Name and Email are set.


### PR DESCRIPTION
## Summary

Three issues prevented `git push` over SSH from working inside the microVM, even though SSH agent forwarding was correctly set up by go-microvm v0.0.23:

- **Missing `~/.ssh/known_hosts`** — the guest had no host keys for github.com, gitlab.com, or bitbucket.org, causing SSH to reject connections with "Host key verification failed". Added `InjectSSHKnownHosts` rootfs hook with verified keys (ed25519, ecdsa, rsa) for all three providers.

- **URL sanitizer stripping SSH usernames** — `sanitizeURL` treated all `url.User` info as credentials, turning `ssh://git@github.com/org/repo` into `ssh://github.com/org/repo`. Fixed to only strip when a password is present; username-only URLs (SSH key auth) are preserved.

- **Missing `insteadOf` URL rewrites** — the host's global `~/.gitconfig` `[url "git@github.com:"].insteadOf` rules were not forwarded to the guest. Repos with HTTPS remotes that relied on host-side rewriting to SSH could not use SSH agent forwarding. Added `URLRewrite` parsing to `HostIdentityProvider` and injection into the guest `.gitconfig`.

## Test plan

- [x] Verified `SSH_AUTH_SOCK` is set inside the VM
- [x] Verified `ssh -T git@github.com` authenticates successfully (known_hosts + agent forwarding)
- [x] Verified `git remote -v` shows SSH URL via insteadOf rewrite
- [x] Verified `~/.gitconfig` inside guest contains the `[url].insteadOf` rule
- [x] All new unit tests pass (`TestInjectSSHKnownHosts_*`, `TestParseURLRewrites`, `TestHostIdentityProvider_URLRewrites`, sanitizer SSH URL tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)