### PR TITLE
Use ByteSize for memory config

### DIFF
--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -65,7 +65,7 @@ func main() {
 func rootCmd() *cobra.Command {
 	var (
 		cpus              uint32
-		memory            uint32
+		memory            string
 		wsPath            string
 		sshPort           uint16
 		cfgPath           string
@@ -107,7 +107,7 @@ Supported agents: claude-code, codex, opencode
 
 Example:
   bbox claude-code
-  bbox codex --cpus 4 --memory 4096
+  bbox codex --cpus 4 --memory 4g
   bbox opencode --workspace /path/to/project
   bbox claude-code --review
   bbox claude-code --review --exclude "*.log" --exclude "tmp/"
@@ -159,7 +159,7 @@ Example:
 	}
 
 	cmd.Flags().Uint32Var(&cpus, "cpus", 0, "Number of vCPUs (0 = agent default)")
-	cmd.Flags().Uint32Var(&memory, "memory", 0, "RAM in MiB (0 = agent default)")
+	cmd.Flags().StringVar(&memory, "memory", "", "RAM for the VM, e.g. 4g or 512m (0 = agent default)")
 	cmd.Flags().StringVar(&tmpSize, "tmp-size", "", "Size of /tmp tmpfs inside the VM, e.g. 512m or 2g (0 = agent default)")
 	cmd.Flags().StringVar(&wsPath, "workspace", "", "Workspace directory to mount (default: current directory)")
 	cmd.Flags().Uint16Var(&sshPort, "ssh-port", 0, "Host SSH port (0 = auto-pick)")
@@ -273,7 +273,7 @@ func authClearCmd() *cobra.Command {
 
 type runFlags struct {
 	cpus              uint32
-	memory            uint32
+	memory            string
 	tmpSize           string
 	workspace         string
 	sshPort           uint16
@@ -422,7 +422,7 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 						Command:       override.Command,
 						EnvForward:    override.EnvForward,
 						DefaultCPUs:   override.CPUs,
-						DefaultMemory: override.Memory,
+						DefaultMemory: override.Memory.MiB(),
 					}); addErr != nil {
 						_, _ = fmt.Fprintf(os.Stderr, "Warning: skipping custom agent %q: %s\n", name, addErr)
 					}
@@ -698,6 +698,16 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		commandOverride = []string{flags.exec}
 	}
 
+	// Parse --memory flag (human-readable string → MiB).
+	var memoryMiB uint32
+	if flags.memory != "" {
+		parsed, parseErr := domainconfig.ParseByteSize(flags.memory)
+		if parseErr != nil {
+			return fmt.Errorf("--memory: %w", parseErr)
+		}
+		memoryMiB = parsed.MiB()
+	}
+
 	// Parse --tmp-size flag (human-readable string → MiB).
 	var tmpSizeMiB uint32
 	if flags.tmpSize != "" {
@@ -717,7 +727,7 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 
 	opts := sandbox.RunOpts{
 		CPUs:            flags.cpus,
-		Memory:          flags.memory,
+		Memory:          memoryMiB,
 		TmpSizeMiB:      tmpSizeMiB,
 		Workspace:       ws,
 		SSHPort:         flags.sshPort,
@@ -931,10 +941,10 @@ func warnLocalConfigOverrides(w io.Writer, localCfg, globalCfg *domainconfig.Con
 	}
 	if localCfg.Defaults.Memory > 0 {
 		if localCfg.Defaults.Memory > domainconfig.MaxMemory {
-			warnings = append(warnings, fmt.Sprintf("sets default memory: %d MiB (clamped to %d MiB)",
+			warnings = append(warnings, fmt.Sprintf("sets default memory: %s (clamped to %s)",
 				localCfg.Defaults.Memory, domainconfig.MaxMemory))
 		} else {
-			warnings = append(warnings, fmt.Sprintf("sets default memory: %d MiB", localCfg.Defaults.Memory))
+			warnings = append(warnings, fmt.Sprintf("sets default memory: %s", localCfg.Defaults.Memory))
 		}
 	}
 
@@ -1009,10 +1019,10 @@ func warnLocalConfigOverrides(w io.Writer, localCfg, globalCfg *domainconfig.Con
 		}
 		if override.Memory > 0 {
 			if override.Memory > domainconfig.MaxMemory {
-				warnings = append(warnings, fmt.Sprintf("sets %s memory: %d MiB (clamped to %d MiB)",
+				warnings = append(warnings, fmt.Sprintf("sets %s memory: %s (clamped to %s)",
 					safeName, override.Memory, domainconfig.MaxMemory))
 			} else {
-				warnings = append(warnings, fmt.Sprintf("sets %s memory: %d MiB", safeName, override.Memory))
+				warnings = append(warnings, fmt.Sprintf("sets %s memory: %s", safeName, override.Memory))
 			}
 		}
 		if override.MCP != nil {

--- a/cmd/bbox/main_test.go
+++ b/cmd/bbox/main_test.go
@@ -147,10 +147,10 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 		{
 			name: "defaults memory",
 			local: &domainconfig.Config{
-				Defaults: domainconfig.DefaultsConfig{Memory: 131072},
+				Defaults: domainconfig.DefaultsConfig{Memory: domainconfig.ByteSize(131072)},
 			},
 			global:   defaultGlobal,
-			expected: wrapWarnings("sets default memory: 131072 MiB"),
+			expected: wrapWarnings("sets default memory: 128g"),
 		},
 		{
 			name: "defaults CPUs clamped",
@@ -164,11 +164,11 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 		{
 			name: "defaults memory clamped",
 			local: &domainconfig.Config{
-				Defaults: domainconfig.DefaultsConfig{Memory: 999999},
+				Defaults: domainconfig.DefaultsConfig{Memory: domainconfig.ByteSize(999999)},
 			},
 			global: defaultGlobal,
-			expected: wrapWarnings(fmt.Sprintf("sets default memory: 999999 MiB (clamped to %d MiB)",
-				domainconfig.MaxMemory)),
+			expected: wrapWarnings(fmt.Sprintf("sets default memory: %s (clamped to %s)",
+				domainconfig.ByteSize(999999), domainconfig.MaxMemory)),
 		},
 		// --- Git ---
 		{
@@ -251,26 +251,26 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 			name: "agent CPUs and memory",
 			local: &domainconfig.Config{
 				Agents: map[string]domainconfig.AgentOverride{
-					"myagent": {CPUs: 128, Memory: 99999},
+					"myagent": {CPUs: 128, Memory: domainconfig.ByteSize(99999)},
 				},
 			},
 			global: defaultGlobal,
 			expected: wrapWarnings(
 				"sets myagent CPUs: 128",
-				"sets myagent memory: 99999 MiB",
+				fmt.Sprintf("sets myagent memory: %s", domainconfig.ByteSize(99999)),
 			),
 		},
 		{
 			name: "agent CPUs and memory clamped",
 			local: &domainconfig.Config{
 				Agents: map[string]domainconfig.AgentOverride{
-					"myagent": {CPUs: 256, Memory: 999999},
+					"myagent": {CPUs: 256, Memory: domainconfig.ByteSize(999999)},
 				},
 			},
 			global: defaultGlobal,
 			expected: wrapWarnings(
 				fmt.Sprintf("sets myagent CPUs: 256 (clamped to %d)", domainconfig.MaxCPUs),
-				fmt.Sprintf("sets myagent memory: 999999 MiB (clamped to %d MiB)", domainconfig.MaxMemory),
+				fmt.Sprintf("sets myagent memory: %s (clamped to %s)", domainconfig.ByteSize(999999), domainconfig.MaxMemory),
 			),
 		},
 		// --- Agent MCP override (CRITICAL-1 fix) ---
@@ -368,7 +368,7 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 				Defaults: domainconfig.DefaultsConfig{
 					EgressProfile: "locked",
 					CPUs:          8,
-					Memory:        4096,
+					Memory:        domainconfig.ByteSize(4096),
 				},
 				Network: domainconfig.NetworkConfig{
 					AllowHosts: []domainconfig.EgressHostConfig{
@@ -401,7 +401,7 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 				"adds review exclude patterns: *.log",
 				"sets default egress profile: locked",
 				"sets default CPUs: 8",
-				"sets default memory: 4096 MiB",
+				"sets default memory: 4g",
 				"adds egress hosts: global-extra.com",
 				"sets git token forwarding: false",
 				"overrides myagent image: custom:v1",

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -12,7 +12,7 @@ and you get a live interactive terminal session.
 bbox claude-code
 
 # Run Codex with more resources
-bbox codex --cpus 4 --memory 4096
+bbox codex --cpus 4 --memory 4g
 
 # Run OpenCode on a specific project
 bbox opencode --workspace /path/to/project
@@ -59,7 +59,7 @@ bbox <agent-name> [flags] [-- <agent-args...>]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--cpus` | Agent default (2) | Number of vCPUs for the VM |
-| `--memory` | Agent default (4096) | RAM in MiB |
+| `--memory` | Agent default (4g) | RAM for the VM (e.g. `4g`, `512m`) |
 | `--workspace` | Current directory | Host directory mounted as `/workspace` |
 | `--ssh-port` | Auto-pick | Host port forwarded to guest SSH (port 22) |
 | `--config` | `~/.config/broodbox/config.yaml` | Config file path |
@@ -137,7 +137,7 @@ override built-in agents, or define custom agents.
 # Global resource defaults (applied when agent doesn't specify its own)
 defaults:
   cpus: 4
-  memory: 4096
+  memory: "4g"
   egress_profile: "permissive"
 
 # Workspace snapshot review settings
@@ -192,7 +192,7 @@ agents:
     env_forward:
       - MY_API_KEY
     cpus: 2
-    memory: 1024
+    memory: "1g"
 ```
 
 ### Config Resolution Order
@@ -289,7 +289,7 @@ defaults:
 ```yaml
 defaults:
   cpus: 4
-  memory: 4096
+  memory: "4g"
 review:
   exclude_patterns:
     - "*.log"

--- a/internal/infra/config/loader_test.go
+++ b/internal/infra/config/loader_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	domainconfig "github.com/stacklok/brood-box/pkg/domain/config"
 )
 
 func TestLoader_Load_FileNotExist(t *testing.T) {
@@ -55,7 +57,7 @@ agents:
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(4), cfg.Defaults.CPUs)
-	assert.Equal(t, uint32(4096), cfg.Defaults.Memory)
+	assert.Equal(t, domainconfig.ByteSize(4096), cfg.Defaults.Memory)
 
 	require.Contains(t, cfg.Agents, "claude-code")
 	cc := cfg.Agents["claude-code"]
@@ -66,7 +68,7 @@ agents:
 	assert.Equal(t, "ghcr.io/me/my-agent:latest", custom.Image)
 	assert.Equal(t, []string{"my-agent", "--interactive"}, custom.Command)
 	assert.Equal(t, uint32(2), custom.CPUs)
-	assert.Equal(t, uint32(1024), custom.Memory)
+	assert.Equal(t, domainconfig.ByteSize(1024), custom.Memory)
 }
 
 func TestLoader_Load_InvalidYAML(t *testing.T) {
@@ -108,7 +110,7 @@ review:
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Equal(t, uint32(8), cfg.Defaults.CPUs)
-	assert.Equal(t, uint32(8192), cfg.Defaults.Memory)
+	assert.Equal(t, domainconfig.ByteSize(8192), cfg.Defaults.Memory)
 	assert.Equal(t, []string{"*.tmp"}, cfg.Review.ExcludePatterns)
 }
 

--- a/pkg/domain/config/config.go
+++ b/pkg/domain/config/config.go
@@ -320,8 +320,8 @@ const (
 	// MaxCPUs is the upper bound for vCPU allocation.
 	MaxCPUs uint32 = 128
 
-	// MaxMemory is the upper bound for RAM allocation in MiB (128 GiB).
-	MaxMemory uint32 = 131072
+	// MaxMemory is the upper bound for RAM allocation (128 GiB).
+	MaxMemory ByteSize = 131072
 
 	// MaxTmpSize is the upper bound for /tmp tmpfs size (64 GiB).
 	MaxTmpSize ByteSize = 65536
@@ -332,8 +332,10 @@ type DefaultsConfig struct {
 	// CPUs is the default number of vCPUs.
 	CPUs uint32 `yaml:"cpus"`
 
-	// Memory is the default RAM in MiB.
-	Memory uint32 `yaml:"memory"`
+	// Memory is the default RAM for the VM. Accepts human-readable values
+	// like "4g" or "512m". Bare integers are treated as MiB for backward
+	// compatibility. Zero uses the agent default.
+	Memory ByteSize `yaml:"memory"`
 
 	// TmpSize is the default /tmp tmpfs size. Accepts human-readable values
 	// like "512m" or "2g". Bare integers are treated as MiB for backward
@@ -371,8 +373,9 @@ type AgentOverride struct {
 	// CPUs overrides the vCPU count.
 	CPUs uint32 `yaml:"cpus,omitempty"`
 
-	// Memory overrides the RAM in MiB.
-	Memory uint32 `yaml:"memory,omitempty"`
+	// Memory overrides the RAM for this agent. Accepts human-readable
+	// values like "4g" or "512m".
+	Memory ByteSize `yaml:"memory,omitempty"`
 
 	// TmpSize overrides the /tmp tmpfs size for this agent. Accepts
 	// human-readable values like "512m" or "2g".
@@ -390,7 +393,7 @@ type AgentOverride struct {
 
 // clampResources caps CPU and memory values to their maximums.
 // Zero values are passed through (they mean "use default").
-func clampResources(cpus, memory uint32) (uint32, uint32) {
+func clampResources(cpus uint32, memory ByteSize) (uint32, ByteSize) {
 	if cpus > MaxCPUs {
 		cpus = MaxCPUs
 	}
@@ -550,10 +553,10 @@ func Merge(a agent.Agent, override AgentOverride, defaults DefaultsConfig) agent
 
 	// Memory: override > agent default > global default
 	if override.Memory > 0 {
-		result.DefaultMemory = override.Memory
+		result.DefaultMemory = override.Memory.MiB()
 	}
 	if result.DefaultMemory == 0 && defaults.Memory > 0 {
-		result.DefaultMemory = defaults.Memory
+		result.DefaultMemory = defaults.Memory.MiB()
 	}
 
 	// TmpSize: override > agent default > global default
@@ -565,9 +568,11 @@ func Merge(a agent.Agent, override AgentOverride, defaults DefaultsConfig) agent
 	}
 
 	// Clamp resource values to configured maximums.
-	result.DefaultCPUs, result.DefaultMemory = clampResources(
-		result.DefaultCPUs, result.DefaultMemory,
+	clampedCPUs, clampedMem := clampResources(
+		result.DefaultCPUs, ByteSize(result.DefaultMemory),
 	)
+	result.DefaultCPUs = clampedCPUs
+	result.DefaultMemory = clampedMem.MiB()
 	if result.DefaultTmpSize > MaxTmpSize.MiB() {
 		result.DefaultTmpSize = MaxTmpSize.MiB()
 	}

--- a/pkg/domain/config/config_test.go
+++ b/pkg/domain/config/config_test.go
@@ -48,15 +48,15 @@ func TestMergeConfigs(t *testing.T) {
 	}{
 		{
 			name:   "nil local returns global unchanged",
-			global: &Config{Defaults: DefaultsConfig{CPUs: 2, Memory: 1024}},
+			global: &Config{Defaults: DefaultsConfig{CPUs: 2, Memory: ByteSize(1024)}},
 			local:  nil,
-			want:   &Config{Defaults: DefaultsConfig{CPUs: 2, Memory: 1024}},
+			want:   &Config{Defaults: DefaultsConfig{CPUs: 2, Memory: ByteSize(1024)}},
 		},
 		{
 			name:   "local scalars override global when non-zero",
-			global: &Config{Defaults: DefaultsConfig{CPUs: 2, Memory: 1024}},
+			global: &Config{Defaults: DefaultsConfig{CPUs: 2, Memory: ByteSize(1024)}},
 			local:  &Config{Defaults: DefaultsConfig{CPUs: 4}},
-			want:   &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: 1024}},
+			want:   &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: ByteSize(1024)}},
 		},
 		{
 			name: "review.enabled from local is ignored",
@@ -345,7 +345,7 @@ func TestMerge(t *testing.T) {
 			agent: baseAgent,
 			override: AgentOverride{
 				CPUs:   4,
-				Memory: 4096,
+				Memory: ByteSize(4096),
 			},
 			defaults: DefaultsConfig{},
 			want: agent.Agent{
@@ -368,7 +368,7 @@ func TestMerge(t *testing.T) {
 			override: AgentOverride{},
 			defaults: DefaultsConfig{
 				CPUs:   2,
-				Memory: 1024,
+				Memory: ByteSize(1024),
 			},
 			want: agent.Agent{
 				Name:                 "minimal",
@@ -384,11 +384,11 @@ func TestMerge(t *testing.T) {
 			agent: agent.Agent{Name: "a", Image: "i:l", Command: []string{"c"}},
 			override: AgentOverride{
 				CPUs:   8,
-				Memory: 8192,
+				Memory: ByteSize(8192),
 			},
 			defaults: DefaultsConfig{
 				CPUs:   2,
-				Memory: 1024,
+				Memory: ByteSize(1024),
 			},
 			want: agent.Agent{
 				Name:                 "a",
@@ -405,7 +405,7 @@ func TestMerge(t *testing.T) {
 			override: AgentOverride{},
 			defaults: DefaultsConfig{
 				CPUs:   1,
-				Memory: 512,
+				Memory: ByteSize(512),
 			},
 			want: baseAgent,
 		},
@@ -681,42 +681,42 @@ func TestMergeConfigs_ResourceBounds(t *testing.T) {
 		global     *Config
 		local      *Config
 		wantCPUs   uint32
-		wantMemory uint32
+		wantMemory ByteSize
 	}{
 		{
 			name:       "normal values pass through",
-			global:     &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: 4096}},
-			local:      &Config{Defaults: DefaultsConfig{CPUs: 8, Memory: 8192}},
+			global:     &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: ByteSize(4096)}},
+			local:      &Config{Defaults: DefaultsConfig{CPUs: 8, Memory: ByteSize(8192)}},
 			wantCPUs:   8,
-			wantMemory: 8192,
+			wantMemory: ByteSize(8192),
 		},
 		{
 			name:       "local CPUs exceed max — clamped",
-			global:     &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: 2048}},
+			global:     &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: ByteSize(2048)}},
 			local:      &Config{Defaults: DefaultsConfig{CPUs: 256}},
 			wantCPUs:   MaxCPUs,
-			wantMemory: 2048,
+			wantMemory: ByteSize(2048),
 		},
 		{
 			name:       "local memory exceeds max — clamped",
-			global:     &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: 2048}},
-			local:      &Config{Defaults: DefaultsConfig{Memory: 999999}},
+			global:     &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: ByteSize(2048)}},
+			local:      &Config{Defaults: DefaultsConfig{Memory: ByteSize(999999)}},
 			wantCPUs:   4,
 			wantMemory: MaxMemory,
 		},
 		{
 			name:       "both exceed max — both clamped",
 			global:     &Config{},
-			local:      &Config{Defaults: DefaultsConfig{CPUs: 500, Memory: 500000}},
+			local:      &Config{Defaults: DefaultsConfig{CPUs: 500, Memory: ByteSize(500000)}},
 			wantCPUs:   MaxCPUs,
 			wantMemory: MaxMemory,
 		},
 		{
 			name:       "zero local does not override global",
-			global:     &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: 2048}},
+			global:     &Config{Defaults: DefaultsConfig{CPUs: 4, Memory: ByteSize(2048)}},
 			local:      &Config{Defaults: DefaultsConfig{}},
 			wantCPUs:   4,
-			wantMemory: 2048,
+			wantMemory: ByteSize(2048),
 		},
 		{
 			name:       "at boundary — exactly max passes through",
@@ -727,7 +727,7 @@ func TestMergeConfigs_ResourceBounds(t *testing.T) {
 		},
 		{
 			name:       "global exceeds max — clamped even without local override",
-			global:     &Config{Defaults: DefaultsConfig{CPUs: 200, Memory: 200000}},
+			global:     &Config{Defaults: DefaultsConfig{CPUs: 200, Memory: ByteSize(200000)}},
 			local:      &Config{},
 			wantCPUs:   MaxCPUs,
 			wantMemory: MaxMemory,
@@ -735,14 +735,14 @@ func TestMergeConfigs_ResourceBounds(t *testing.T) {
 		{
 			name:       "one over one under — only over is clamped",
 			global:     &Config{Defaults: DefaultsConfig{CPUs: 4}},
-			local:      &Config{Defaults: DefaultsConfig{Memory: 999999}},
+			local:      &Config{Defaults: DefaultsConfig{Memory: ByteSize(999999)}},
 			wantCPUs:   4,
 			wantMemory: MaxMemory,
 		},
 		{
 			name:       "MaxUint32 values are clamped",
 			global:     &Config{},
-			local:      &Config{Defaults: DefaultsConfig{CPUs: math.MaxUint32, Memory: math.MaxUint32}},
+			local:      &Config{Defaults: DefaultsConfig{CPUs: math.MaxUint32, Memory: ByteSize(math.MaxUint32)}},
 			wantCPUs:   MaxCPUs,
 			wantMemory: MaxMemory,
 		},
@@ -998,7 +998,7 @@ func TestMerge_ResourceBounds(t *testing.T) {
 		{
 			name:       "normal values pass through",
 			agent:      baseAgent,
-			override:   AgentOverride{CPUs: 4, Memory: 4096},
+			override:   AgentOverride{CPUs: 4, Memory: ByteSize(4096)},
 			defaults:   DefaultsConfig{},
 			wantCPUs:   4,
 			wantMemory: 4096,
@@ -1014,18 +1014,18 @@ func TestMerge_ResourceBounds(t *testing.T) {
 		{
 			name:       "override memory exceeds max — clamped",
 			agent:      baseAgent,
-			override:   AgentOverride{Memory: 999999},
+			override:   AgentOverride{Memory: ByteSize(999999)},
 			defaults:   DefaultsConfig{},
 			wantCPUs:   2,
-			wantMemory: MaxMemory,
+			wantMemory: MaxMemory.MiB(),
 		},
 		{
 			name:       "global defaults exceed max — clamped",
 			agent:      agent.Agent{Name: "a", Image: "i:l", Command: []string{"c"}, DefaultEgressProfile: "standard"},
 			override:   AgentOverride{},
-			defaults:   DefaultsConfig{CPUs: 500, Memory: 500000},
+			defaults:   DefaultsConfig{CPUs: 500, Memory: ByteSize(500000)},
 			wantCPUs:   MaxCPUs,
-			wantMemory: MaxMemory,
+			wantMemory: MaxMemory.MiB(),
 		},
 		{
 			name:       "agent defaults exceed max — clamped",
@@ -1033,7 +1033,7 @@ func TestMerge_ResourceBounds(t *testing.T) {
 			override:   AgentOverride{},
 			defaults:   DefaultsConfig{},
 			wantCPUs:   MaxCPUs,
-			wantMemory: MaxMemory,
+			wantMemory: MaxMemory.MiB(),
 		},
 		{
 			name:       "zero override uses agent defaults",
@@ -1049,15 +1049,15 @@ func TestMerge_ResourceBounds(t *testing.T) {
 			override:   AgentOverride{CPUs: MaxCPUs, Memory: MaxMemory},
 			defaults:   DefaultsConfig{},
 			wantCPUs:   MaxCPUs,
-			wantMemory: MaxMemory,
+			wantMemory: MaxMemory.MiB(),
 		},
 		{
 			name:       "MaxUint32 values are clamped",
 			agent:      baseAgent,
-			override:   AgentOverride{CPUs: math.MaxUint32, Memory: math.MaxUint32},
+			override:   AgentOverride{CPUs: math.MaxUint32, Memory: ByteSize(math.MaxUint32)},
 			defaults:   DefaultsConfig{},
 			wantCPUs:   MaxCPUs,
-			wantMemory: MaxMemory,
+			wantMemory: MaxMemory.MiB(),
 		},
 	}
 

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -248,7 +248,7 @@ func (s *SandboxRunner) Prepare(ctx context.Context, agentName string, opts RunO
 		override.CPUs = opts.CPUs
 	}
 	if opts.Memory > 0 {
-		override.Memory = opts.Memory
+		override.Memory = config.ByteSize(opts.Memory)
 	}
 	if opts.TmpSizeMiB > 0 {
 		override.TmpSize = config.ByteSize(opts.TmpSizeMiB)


### PR DESCRIPTION
## Summary

- Change `DefaultsConfig.Memory` and `AgentOverride.Memory` from `uint32` to `ByteSize`, matching the existing `TmpSize` pattern
- Update `--memory` CLI flag from `Uint32Var` to `StringVar` with `ParseByteSize()`, so users write `--memory 4g` instead of `--memory 4096`
- Update `MaxMemory` constant to `ByteSize` and adapt `clampResources()` and `Merge()` accordingly
- Update docs and config examples to use human-readable format (`"4g"`, `"512m"`)

Bare integers in YAML config are still accepted (backward compatible via `ByteSize.UnmarshalText`).

## Test plan

- [x] `task fmt && task lint` — 0 issues
- [x] `task test` — all tests pass
- [ ] Manual: verify `bbox claude-code --memory 4g` works
- [ ] Manual: verify `memory: "4g"` in config.yaml works
- [ ] Manual: verify bare integer `memory: 4096` still works (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)