### PR TITLE
Narrow per-agent MCP override type and add authz support

### DIFF
--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -653,6 +653,14 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 			authzCfg = &domainconfig.MCPAuthzConfig{Profile: domainconfig.MCPAuthzProfileCustom}
 		}
 
+		// Merge per-agent authz override (tighten-only) before constructing
+		// the VMCPProvider singleton.
+		if cfg != nil {
+			if ao, ok := cfg.Agents[agentName]; ok && ao.MCP != nil && ao.MCP.Authz != nil {
+				authzCfg = domainconfig.MergeMCPAuthzConfig(authzCfg, ao.MCP.Authz)
+			}
+		}
+
 		mcpProvider := inframcp.NewVMCPProvider(mcpGroup, mcpPort, mcpFileConfig, authzCfg, logger, logFile)
 		deps.MCPProvider = mcpProvider
 		defer func() { _ = mcpProvider.Close() }()
@@ -1058,14 +1066,13 @@ func warnLocalConfigOverrides(w io.Writer, localCfg, globalCfg *domainconfig.Con
 			if override.MCP.Enabled != nil {
 				warnings = append(warnings, fmt.Sprintf("sets %s MCP enabled: %t", safeName, *override.MCP.Enabled))
 			}
-			if override.MCP.Group != "" {
-				warnings = append(warnings, fmt.Sprintf("sets %s MCP group: %s", safeName, sanitizeValue(override.MCP.Group)))
-			}
-			if override.MCP.Port != 0 {
-				warnings = append(warnings, fmt.Sprintf("sets %s MCP port: %d", safeName, override.MCP.Port))
-			}
-			if override.MCP.Config != nil {
-				warnings = append(warnings, fmt.Sprintf("sets %s MCP config (inline Cedar policies/aggregation)", safeName))
+			if override.MCP.Authz != nil && override.MCP.Authz.Profile != "" {
+				profile := sanitizeValue(override.MCP.Authz.Profile)
+				if override.MCP.Authz.Profile == domainconfig.MCPAuthzProfileCustom {
+					warnings = append(warnings, fmt.Sprintf("%s MCP authz profile %q is ignored — custom profiles cannot be set from workspace config", safeName, profile))
+				} else {
+					warnings = append(warnings, fmt.Sprintf("sets %s MCP authz profile: %s (can only tighten, not widen)", safeName, profile))
+				}
 			}
 		}
 	}

--- a/cmd/bbox/main_test.go
+++ b/cmd/bbox/main_test.go
@@ -273,21 +273,15 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 				fmt.Sprintf("sets myagent memory: %s (clamped to %s)", domainconfig.ByteSize(999999), domainconfig.MaxMemory),
 			),
 		},
-		// --- Agent MCP override (CRITICAL-1 fix) ---
+		// --- Agent MCP override ---
 		{
-			name: "agent MCP override all fields",
+			name: "agent MCP override enabled and authz",
 			local: &domainconfig.Config{
 				Agents: map[string]domainconfig.AgentOverride{
 					"myagent": {
-						MCP: &domainconfig.MCPConfig{
+						MCP: &domainconfig.MCPAgentOverride{
 							Enabled: boolPtr(false),
-							Group:   "evil-group",
-							Port:    9999,
-							Config: &domainconfig.MCPFileConfig{
-								Authz: &domainconfig.MCPFileAuthzConfig{
-									Policies: []string{`permit(principal, action, resource);`},
-								},
-							},
+							Authz:   &domainconfig.MCPAuthzConfig{Profile: domainconfig.MCPAuthzProfileObserve},
 						},
 					},
 				},
@@ -295,9 +289,23 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 			global: defaultGlobal,
 			expected: wrapWarnings(
 				"sets myagent MCP enabled: false",
-				"sets myagent MCP group: evil-group",
-				"sets myagent MCP port: 9999",
-				"sets myagent MCP config (inline Cedar policies/aggregation)",
+				"sets myagent MCP authz profile: observe (can only tighten, not widen)",
+			),
+		},
+		{
+			name: "agent MCP authz custom ignored",
+			local: &domainconfig.Config{
+				Agents: map[string]domainconfig.AgentOverride{
+					"myagent": {
+						MCP: &domainconfig.MCPAgentOverride{
+							Authz: &domainconfig.MCPAuthzConfig{Profile: domainconfig.MCPAuthzProfileCustom},
+						},
+					},
+				},
+			},
+			global: defaultGlobal,
+			expected: wrapWarnings(
+				`myagent MCP authz profile "custom" is ignored — custom profiles cannot be set from workspace config`,
 			),
 		},
 		// --- Ordering ---
@@ -387,8 +395,8 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 						AllowHosts: []domainconfig.EgressHostConfig{
 							{Name: "agent-extra.com"},
 						},
-						MCP: &domainconfig.MCPConfig{
-							Group: "custom",
+						MCP: &domainconfig.MCPAgentOverride{
+							Authz: &domainconfig.MCPAuthzConfig{Profile: domainconfig.MCPAuthzProfileObserve},
 						},
 					},
 				},
@@ -409,7 +417,7 @@ func TestWarnLocalConfigOverrides(t *testing.T) {
 				"overrides myagent env forwarding",
 				"adds myagent egress hosts: agent-extra.com",
 				"sets myagent egress profile: locked",
-				"sets myagent MCP group: custom",
+				"sets myagent MCP authz profile: observe (can only tighten, not widen)",
 			),
 		},
 	}

--- a/pkg/domain/config/config.go
+++ b/pkg/domain/config/config.go
@@ -365,6 +365,20 @@ func StricterMCPAuthzProfile(a, b string) string {
 	return a
 }
 
+// MCPAgentOverride holds the subset of MCP settings that can be
+// overridden per-agent. Only Enabled (gate) and Authz (tighten-only)
+// have runtime effect at the per-agent level.
+type MCPAgentOverride struct {
+	// Enabled controls whether the MCP proxy is active for this agent.
+	// nil means "no override" (inherit global setting), unlike
+	// MCPConfig.Enabled where nil defaults to true.
+	Enabled *bool `yaml:"enabled,omitempty"`
+
+	// Authz overrides the MCP authorization profile for this agent.
+	// Tighten-only: can only make the profile stricter, not more permissive.
+	Authz *MCPAuthzConfig `yaml:"authz,omitempty"`
+}
+
 // IsEnabled returns whether the MCP proxy is enabled.
 // Defaults to true when Enabled is nil.
 func (m MCPConfig) IsEnabled() bool {
@@ -457,7 +471,8 @@ type AgentOverride struct {
 	AllowHosts []EgressHostConfig `yaml:"allow_hosts,omitempty"`
 
 	// MCP overrides the global MCP proxy settings for this agent.
-	MCP *MCPConfig `yaml:"mcp,omitempty"`
+	// Only Enabled (gate) and Authz (tighten-only) are supported.
+	MCP *MCPAgentOverride `yaml:"mcp,omitempty"`
 
 	// SettingsImport overrides the global settings import for this agent.
 	SettingsImport *SettingsImportConfig `yaml:"settings_import,omitempty"`
@@ -569,13 +584,12 @@ func MergeConfigs(global, local *Config) *Config {
 
 	// MCP.Authz: local can only tighten (not widen). Same security pattern
 	// as egress profiles — a workspace config cannot escalate permissions.
-	result.MCP.Authz = mergeMCPAuthzConfig(global.MCP.Authz, local.MCP.Authz)
+	result.MCP.Authz = MergeMCPAuthzConfig(global.MCP.Authz, local.MCP.Authz)
 
 	// Agents: local extends/overrides global per key.
-	// MCP.Config and MCP.Authz are stripped from local overrides — workspace
-	// config must not inject Cedar policies, aggregation settings, or authz
-	// profiles through per-agent overrides (same security pattern as top-level
-	// MCP.Authz tighten-only and Auth ignore).
+	// Per-agent MCP.Authz uses tighten-only merge: workspace config can only
+	// make the profile stricter, not more permissive. "custom" from workspace
+	// config is blocked by MergeMCPAuthzConfig.
 	if len(local.Agents) > 0 {
 		if result.Agents == nil {
 			result.Agents = make(map[string]AgentOverride)
@@ -588,10 +602,15 @@ func MergeConfigs(global, local *Config) *Config {
 			result.Agents = merged
 		}
 		for k, v := range local.Agents {
-			if v.MCP != nil && (v.MCP.Config != nil || v.MCP.Authz != nil) {
+			if v.MCP != nil && v.MCP.Authz != nil {
+				// Merge local per-agent authz with the global per-agent authz
+				// (if any) using tighten-only semantics.
+				var globalAgentAuthz *MCPAuthzConfig
+				if ga, ok := result.Agents[k]; ok && ga.MCP != nil {
+					globalAgentAuthz = ga.MCP.Authz
+				}
 				sanitized := *v.MCP
-				sanitized.Config = nil
-				sanitized.Authz = nil
+				sanitized.Authz = MergeMCPAuthzConfig(globalAgentAuthz, v.MCP.Authz)
 				v.MCP = &sanitized
 			}
 			result.Agents[k] = v
@@ -690,12 +709,12 @@ func mergeGitConfig(global, local GitConfig) GitConfig {
 	return result
 }
 
-// mergeMCPAuthzConfig merges local into global using tighten-only semantics.
+// MergeMCPAuthzConfig merges local into global using tighten-only semantics.
 // Local can only make the profile stricter, never more permissive.
 // "custom" from local config is silently ignored (security: local config must
 // not be able to switch to operator-controlled Cedar policies).
 // Returns nil when neither side sets an authz config.
-func mergeMCPAuthzConfig(global, local *MCPAuthzConfig) *MCPAuthzConfig {
+func MergeMCPAuthzConfig(global, local *MCPAuthzConfig) *MCPAuthzConfig {
 	if local == nil || local.Profile == "" {
 		return global
 	}

--- a/pkg/domain/config/config.go
+++ b/pkg/domain/config/config.go
@@ -587,9 +587,9 @@ func MergeConfigs(global, local *Config) *Config {
 	result.MCP.Authz = MergeMCPAuthzConfig(global.MCP.Authz, local.MCP.Authz)
 
 	// Agents: local extends/overrides global per key.
-	// Per-agent MCP.Authz uses tighten-only merge: workspace config can only
-	// make the profile stricter, not more permissive. "custom" from workspace
-	// config is blocked by MergeMCPAuthzConfig.
+	// Security fields (EgressProfile, MCP.Authz) use tighten-only merge.
+	// Resource/identity fields use local-overrides-when-non-zero.
+	// AllowHosts are additive.
 	if len(local.Agents) > 0 {
 		if result.Agents == nil {
 			result.Agents = make(map[string]AgentOverride)
@@ -602,16 +602,11 @@ func MergeConfigs(global, local *Config) *Config {
 			result.Agents = merged
 		}
 		for k, v := range local.Agents {
-			if v.MCP != nil && v.MCP.Authz != nil {
-				// Merge local per-agent authz with the global per-agent authz
-				// (if any) using tighten-only semantics.
-				var globalAgentAuthz *MCPAuthzConfig
-				if ga, ok := result.Agents[k]; ok && ga.MCP != nil {
-					globalAgentAuthz = ga.MCP.Authz
-				}
-				sanitized := *v.MCP
-				sanitized.Authz = MergeMCPAuthzConfig(globalAgentAuthz, v.MCP.Authz)
-				v.MCP = &sanitized
+			if ga, ok := result.Agents[k]; ok {
+				v = mergeAgentOverride(ga, v)
+			} else {
+				// New agent from local — still sanitize security fields.
+				v = sanitizeNewAgentOverride(v)
 			}
 			result.Agents[k] = v
 		}
@@ -791,6 +786,102 @@ func TightenSettingsCategories(global, local *SettingsCategoryConfig) *SettingsC
 	tightenBool(&result.Themes, local.Themes)
 
 	return &result
+}
+
+// mergeAgentOverride merges a local (workspace) agent override into a global one.
+// Rules mirror the top-level MergeConfigs patterns:
+//   - Resource/identity fields (Image, Command, EnvForward, CPUs, Memory, TmpSize):
+//     local overrides global when non-zero.
+//   - EgressProfile: tighten-only via egress.Stricter.
+//   - AllowHosts: additive (global + local).
+//   - MCP.Enabled: local overrides global.
+//   - MCP.Authz: tighten-only via MergeMCPAuthzConfig.
+//   - SettingsImport: tighten-only via mergeSettingsImportConfig.
+func mergeAgentOverride(global, local AgentOverride) AgentOverride {
+	result := global
+
+	// Resource/identity: local overrides when non-zero.
+	if local.Image != "" {
+		result.Image = local.Image
+	}
+	if len(local.Command) > 0 {
+		result.Command = local.Command
+	}
+	if len(local.EnvForward) > 0 {
+		result.EnvForward = local.EnvForward
+	}
+	if local.CPUs > 0 {
+		result.CPUs = local.CPUs
+	}
+	if local.Memory > 0 {
+		result.Memory = local.Memory
+	}
+	if local.TmpSize > 0 {
+		result.TmpSize = local.TmpSize
+	}
+
+	// EgressProfile: tighten-only, matching top-level Defaults.EgressProfile merge.
+	if local.EgressProfile != "" {
+		effectiveGlobal := egress.ProfileName(result.EgressProfile)
+		if effectiveGlobal == "" {
+			effectiveGlobal = egress.ProfilePermissive
+		}
+		result.EgressProfile = string(egress.Stricter(
+			effectiveGlobal,
+			egress.ProfileName(local.EgressProfile),
+		))
+	}
+
+	// AllowHosts: additive, matching Network.AllowHosts merge.
+	if len(local.AllowHosts) > 0 {
+		result.AllowHosts = append(
+			append([]EgressHostConfig{}, result.AllowHosts...),
+			local.AllowHosts...,
+		)
+	}
+
+	// MCP: merge Enabled and Authz separately.
+	if local.MCP != nil {
+		if result.MCP == nil {
+			result.MCP = &MCPAgentOverride{}
+		} else {
+			// Copy to avoid mutating the global.
+			cp := *result.MCP
+			result.MCP = &cp
+		}
+		if local.MCP.Enabled != nil {
+			result.MCP.Enabled = local.MCP.Enabled
+		}
+		result.MCP.Authz = MergeMCPAuthzConfig(result.MCP.Authz, local.MCP.Authz)
+	}
+
+	// SettingsImport: tighten-only, matching top-level merge.
+	if local.SettingsImport != nil {
+		if result.SettingsImport == nil {
+			// Local can only disable — when global has no settings import
+			// config, only honour an explicit disable from local.
+			if local.SettingsImport.Enabled != nil && !*local.SettingsImport.Enabled {
+				result.SettingsImport = local.SettingsImport
+			}
+		} else {
+			merged := mergeSettingsImportConfig(*result.SettingsImport, *local.SettingsImport)
+			result.SettingsImport = &merged
+		}
+	}
+
+	return result
+}
+
+// sanitizeNewAgentOverride strips security-sensitive fields that a workspace
+// config must not set on a brand-new agent (one with no global counterpart).
+// "custom" MCP authz profile is blocked (same as MergeMCPAuthzConfig).
+func sanitizeNewAgentOverride(ao AgentOverride) AgentOverride {
+	if ao.MCP != nil && ao.MCP.Authz != nil && ao.MCP.Authz.Profile == MCPAuthzProfileCustom {
+		sanitized := *ao.MCP
+		sanitized.Authz = nil
+		ao.MCP = &sanitized
+	}
+	return ao
 }
 
 // ToEgressHosts converts config host entries to domain egress hosts.

--- a/pkg/domain/config/config_test.go
+++ b/pkg/domain/config/config_test.go
@@ -1030,7 +1030,7 @@ func TestMergeConfigs_AgentOverridesMCPAuthzTightenOnly(t *testing.T) {
 			wantEnabled: boolPtr(false),
 		},
 		{
-			name: "local MCP with only Enabled set does not inject authz",
+			name: "local MCP with only Enabled set preserves global authz",
 			global: &Config{
 				Agents: map[string]AgentOverride{
 					"claude-code": {
@@ -1050,7 +1050,7 @@ func TestMergeConfigs_AgentOverridesMCPAuthzTightenOnly(t *testing.T) {
 				},
 			},
 			agent:       "claude-code",
-			wantAuthz:   nil,
+			wantAuthz:   &MCPAuthzConfig{Profile: MCPAuthzProfileSafeTools},
 			wantEnabled: boolPtr(false),
 		},
 	}
@@ -1104,6 +1104,198 @@ func TestMergeConfigs_AgentOverridesMCPDoesNotMutateGlobal(t *testing.T) {
 	// Global agent override must not be mutated.
 	assert.NotNil(t, global.Agents["claude-code"].MCP.Authz, "global input must not be mutated")
 	assert.Equal(t, MCPAuthzProfileObserve, global.Agents["claude-code"].MCP.Authz.Profile)
+}
+
+func TestMergeAgentOverride_FieldByField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		global AgentOverride
+		local  AgentOverride
+		want   AgentOverride
+	}{
+		{
+			name: "local resource override preserves global security fields",
+			global: AgentOverride{
+				Image: "original:v1",
+				MCP: &MCPAgentOverride{
+					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+				},
+				EgressProfile: "locked",
+			},
+			local: AgentOverride{
+				CPUs: 4,
+			},
+			want: AgentOverride{
+				Image: "original:v1",
+				CPUs:  4,
+				MCP: &MCPAgentOverride{
+					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+				},
+				EgressProfile: "locked",
+			},
+		},
+		{
+			name: "local egress profile tighten-only — cannot widen",
+			global: AgentOverride{
+				EgressProfile: "locked",
+			},
+			local: AgentOverride{
+				EgressProfile: "permissive",
+			},
+			want: AgentOverride{
+				EgressProfile: "locked",
+			},
+		},
+		{
+			name: "local egress profile can tighten",
+			global: AgentOverride{
+				EgressProfile: "standard",
+			},
+			local: AgentOverride{
+				EgressProfile: "locked",
+			},
+			want: AgentOverride{
+				EgressProfile: "locked",
+			},
+		},
+		{
+			name:   "local egress profile tightens implicit permissive",
+			global: AgentOverride{},
+			local: AgentOverride{
+				EgressProfile: "standard",
+			},
+			want: AgentOverride{
+				EgressProfile: "standard",
+			},
+		},
+		{
+			name: "allow hosts are additive",
+			global: AgentOverride{
+				AllowHosts: []EgressHostConfig{{Name: "a.example.com"}},
+			},
+			local: AgentOverride{
+				AllowHosts: []EgressHostConfig{{Name: "b.example.com"}},
+			},
+			want: AgentOverride{
+				AllowHosts: []EgressHostConfig{
+					{Name: "a.example.com"},
+					{Name: "b.example.com"},
+				},
+			},
+		},
+		{
+			name: "MCP authz tighten-only via field-by-field merge",
+			global: AgentOverride{
+				MCP: &MCPAgentOverride{
+					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileSafeTools},
+				},
+			},
+			local: AgentOverride{
+				MCP: &MCPAgentOverride{
+					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+				},
+			},
+			want: AgentOverride{
+				MCP: &MCPAgentOverride{
+					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+				},
+			},
+		},
+		{
+			name: "MCP enabled override preserves global authz",
+			global: AgentOverride{
+				MCP: &MCPAgentOverride{
+					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+				},
+			},
+			local: AgentOverride{
+				MCP: &MCPAgentOverride{
+					Enabled: boolPtr(false),
+				},
+			},
+			want: AgentOverride{
+				MCP: &MCPAgentOverride{
+					Enabled: boolPtr(false),
+					Authz:   &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+				},
+			},
+		},
+		{
+			name: "all resource fields override when non-zero",
+			global: AgentOverride{
+				Image:      "old:v1",
+				Command:    []string{"old-cmd"},
+				EnvForward: []string{"OLD_*"},
+				CPUs:       2,
+				Memory:     ByteSize(2048),
+				TmpSize:    ByteSize(512),
+			},
+			local: AgentOverride{
+				Image:      "new:v2",
+				Command:    []string{"new-cmd", "--flag"},
+				EnvForward: []string{"NEW_*"},
+				CPUs:       8,
+				Memory:     ByteSize(8192),
+				TmpSize:    ByteSize(1024),
+			},
+			want: AgentOverride{
+				Image:      "new:v2",
+				Command:    []string{"new-cmd", "--flag"},
+				EnvForward: []string{"NEW_*"},
+				CPUs:       8,
+				Memory:     ByteSize(8192),
+				TmpSize:    ByteSize(1024),
+			},
+		},
+		{
+			name:   "zero local is a no-op",
+			global: AgentOverride{Image: "keep", CPUs: 4},
+			local:  AgentOverride{},
+			want:   AgentOverride{Image: "keep", CPUs: 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := mergeAgentOverride(tt.global, tt.local)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMergeConfigs_AgentOverridePreservesSecurityFields(t *testing.T) {
+	t.Parallel()
+
+	// Exact scenario from review: local sets cpus, global has MCP authz + egress.
+	global := &Config{
+		Agents: map[string]AgentOverride{
+			"claude-code": {
+				MCP: &MCPAgentOverride{
+					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+				},
+				EgressProfile: "locked",
+			},
+		},
+	}
+	local := &Config{
+		Agents: map[string]AgentOverride{
+			"claude-code": {
+				CPUs: 4,
+			},
+		},
+	}
+
+	result := MergeConfigs(global, local)
+	ao := result.Agents["claude-code"]
+
+	assert.Equal(t, uint32(4), ao.CPUs, "CPUs should be overridden")
+	require.NotNil(t, ao.MCP, "MCP should be preserved from global")
+	require.NotNil(t, ao.MCP.Authz, "MCP.Authz should be preserved from global")
+	assert.Equal(t, MCPAuthzProfileObserve, ao.MCP.Authz.Profile, "authz profile should survive")
+	assert.Equal(t, "locked", ao.EgressProfile, "egress profile should survive")
 }
 
 func TestMergeConfigs_SettingsImport(t *testing.T) {

--- a/pkg/domain/config/config_test.go
+++ b/pkg/domain/config/config_test.go
@@ -917,18 +917,173 @@ func TestMergeConfigs_MCPAuthz(t *testing.T) {
 	}
 }
 
-func TestMergeConfigs_AgentOverridesMCPSecurityFieldsStripped(t *testing.T) {
+func TestMergeConfigs_AgentOverridesMCPAuthzTightenOnly(t *testing.T) {
 	t.Parallel()
 
-	policies := []string{`permit(principal, action, resource);`}
+	tests := []struct {
+		name        string
+		global      *Config
+		local       *Config
+		agent       string
+		wantAuthz   *MCPAuthzConfig
+		wantEnabled *bool // if non-nil, assert MCP.Enabled matches
+	}{
+		{
+			name: "local can tighten per-agent authz — observe beats safe-tools",
+			global: &Config{
+				Agents: map[string]AgentOverride{
+					"claude-code": {
+						MCP: &MCPAgentOverride{
+							Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileSafeTools},
+						},
+					},
+				},
+			},
+			local: &Config{
+				Agents: map[string]AgentOverride{
+					"claude-code": {
+						MCP: &MCPAgentOverride{
+							Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+						},
+					},
+				},
+			},
+			agent:     "claude-code",
+			wantAuthz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+		},
+		{
+			name: "local cannot widen per-agent authz — full-access blocked by observe",
+			global: &Config{
+				Agents: map[string]AgentOverride{
+					"claude-code": {
+						MCP: &MCPAgentOverride{
+							Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+						},
+					},
+				},
+			},
+			local: &Config{
+				Agents: map[string]AgentOverride{
+					"claude-code": {
+						MCP: &MCPAgentOverride{
+							Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileFullAccess},
+						},
+					},
+				},
+			},
+			agent:     "claude-code",
+			wantAuthz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+		},
+		{
+			name:   "local sets per-agent authz when global has none",
+			global: &Config{},
+			local: &Config{
+				Agents: map[string]AgentOverride{
+					"codex": {
+						MCP: &MCPAgentOverride{
+							Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileSafeTools},
+						},
+					},
+				},
+			},
+			agent:     "codex",
+			wantAuthz: &MCPAuthzConfig{Profile: MCPAuthzProfileSafeTools},
+		},
+		{
+			name:   "custom from local per-agent config is ignored",
+			global: &Config{},
+			local: &Config{
+				Agents: map[string]AgentOverride{
+					"codex": {
+						MCP: &MCPAgentOverride{
+							Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileCustom},
+						},
+					},
+				},
+			},
+			agent:     "codex",
+			wantAuthz: nil,
+		},
+		{
+			name: "enabled field survives alongside authz merge",
+			global: &Config{
+				Agents: map[string]AgentOverride{
+					"claude-code": {
+						MCP: &MCPAgentOverride{
+							Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileSafeTools},
+						},
+					},
+				},
+			},
+			local: &Config{
+				Agents: map[string]AgentOverride{
+					"claude-code": {
+						MCP: &MCPAgentOverride{
+							Enabled: boolPtr(false),
+							Authz:   &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+						},
+					},
+				},
+			},
+			agent:       "claude-code",
+			wantAuthz:   &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
+			wantEnabled: boolPtr(false),
+		},
+		{
+			name: "local MCP with only Enabled set does not inject authz",
+			global: &Config{
+				Agents: map[string]AgentOverride{
+					"claude-code": {
+						MCP: &MCPAgentOverride{
+							Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileSafeTools},
+						},
+					},
+				},
+			},
+			local: &Config{
+				Agents: map[string]AgentOverride{
+					"claude-code": {
+						MCP: &MCPAgentOverride{
+							Enabled: boolPtr(false),
+						},
+					},
+				},
+			},
+			agent:       "claude-code",
+			wantAuthz:   nil,
+			wantEnabled: boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := MergeConfigs(tt.global, tt.local)
+			agentOverride, ok := result.Agents[tt.agent]
+			if tt.wantAuthz == nil {
+				if ok && agentOverride.MCP != nil && agentOverride.MCP.Authz != nil {
+					t.Errorf("expected nil authz, got %+v", agentOverride.MCP.Authz)
+				}
+			} else {
+				require.True(t, ok, "agent should exist in result")
+				require.NotNil(t, agentOverride.MCP, "MCP should be present")
+				assert.Equal(t, tt.wantAuthz, agentOverride.MCP.Authz)
+			}
+			if tt.wantEnabled != nil && ok && agentOverride.MCP != nil {
+				require.NotNil(t, agentOverride.MCP.Enabled, "MCP.Enabled should be set")
+				assert.Equal(t, *tt.wantEnabled, *agentOverride.MCP.Enabled, "MCP.Enabled")
+			}
+		})
+	}
+}
+
+func TestMergeConfigs_AgentOverridesMCPDoesNotMutateGlobal(t *testing.T) {
+	t.Parallel()
+
 	global := &Config{
 		Agents: map[string]AgentOverride{
 			"claude-code": {
-				MCP: &MCPConfig{
-					Group: "global-group",
-					Config: &MCPFileConfig{
-						Authz: &MCPFileAuthzConfig{Policies: policies},
-					},
+				MCP: &MCPAgentOverride{
 					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileObserve},
 				},
 			},
@@ -937,42 +1092,18 @@ func TestMergeConfigs_AgentOverridesMCPSecurityFieldsStripped(t *testing.T) {
 	local := &Config{
 		Agents: map[string]AgentOverride{
 			"claude-code": {
-				MCP: &MCPConfig{
-					Group: "local-group",
-					Config: &MCPFileConfig{
-						Authz: &MCPFileAuthzConfig{Policies: policies},
-					},
-					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileFullAccess},
-				},
-			},
-			"codex": {
-				MCP: &MCPConfig{
-					Config: &MCPFileConfig{
-						Authz: &MCPFileAuthzConfig{Policies: policies},
-					},
+				MCP: &MCPAgentOverride{
 					Authz: &MCPAuthzConfig{Profile: MCPAuthzProfileSafeTools},
 				},
 			},
 		},
 	}
 
-	result := MergeConfigs(global, local)
+	_ = MergeConfigs(global, local)
 
-	// Local agent override MCP.Config and MCP.Authz must be stripped.
-	claude := result.Agents["claude-code"]
-	assert.NotNil(t, claude.MCP, "MCP should be preserved")
-	assert.Equal(t, "local-group", claude.MCP.Group, "non-security MCP fields should survive")
-	assert.Nil(t, claude.MCP.Config, "MCP.Config from local override must be stripped")
-	assert.Nil(t, claude.MCP.Authz, "MCP.Authz from local override must be stripped")
-
-	codex := result.Agents["codex"]
-	assert.NotNil(t, codex.MCP)
-	assert.Nil(t, codex.MCP.Config, "MCP.Config from local override must be stripped")
-	assert.Nil(t, codex.MCP.Authz, "MCP.Authz from local override must be stripped")
-
-	// Global agent override security fields are preserved (trusted config).
-	assert.NotNil(t, global.Agents["claude-code"].MCP.Config, "global input must not be mutated")
+	// Global agent override must not be mutated.
 	assert.NotNil(t, global.Agents["claude-code"].MCP.Authz, "global input must not be mutated")
+	assert.Equal(t, MCPAuthzProfileObserve, global.Agents["claude-code"].MCP.Authz.Profile)
 }
 
 func TestMergeConfigs_SettingsImport(t *testing.T) {

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -749,27 +749,20 @@ func (s *SandboxRunner) resolveSettingsManifest(
 }
 
 // resolveMCPConfig returns the effective MCP configuration by merging
-// global config with any agent-specific override.
+// global config with any agent-specific Enabled override.
+// Per-agent authz is handled at the composition root (cmd/bbox/main.go)
+// where the VMCPProvider is constructed.
 func (s *SandboxRunner) resolveMCPConfig(cfg *SandboxConfig, agentName string) config.MCPConfig {
 	mcpCfg := cfg.MCP
 
-	// Apply agent-specific override if present.
+	// Apply agent-specific Enabled override if present.
 	if override, ok := cfg.AgentOverrides[agentName]; ok && override.MCP != nil {
 		if override.MCP.Enabled != nil {
 			mcpCfg.Enabled = override.MCP.Enabled
 		}
-		if override.MCP.Group != "" {
-			mcpCfg.Group = override.MCP.Group
-		}
-		if override.MCP.Port != 0 {
-			mcpCfg.Port = override.MCP.Port
-		}
-		if override.MCP.Config != nil {
-			mcpCfg.Config = override.MCP.Config
-		}
 	}
 
-	// Apply defaults.
+	// Apply defaults for log message.
 	if mcpCfg.Group == "" {
 		mcpCfg.Group = "default"
 	}

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stacklok/brood-box/pkg/domain/workspace"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 // mockVMRunner records the config it was called with.
 type mockVMRunner struct {
 	startCfg domvm.VMConfig
@@ -1432,18 +1434,20 @@ func TestResolveMCPConfig(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		cfg       *SandboxConfig
-		agentName string
-		wantGroup string
-		wantPort  uint16
+		name        string
+		cfg         *SandboxConfig
+		agentName   string
+		wantGroup   string
+		wantPort    uint16
+		wantEnabled bool
 	}{
 		{
-			name:      "zero config applies defaults",
-			cfg:       &SandboxConfig{},
-			agentName: "test",
-			wantGroup: "default",
-			wantPort:  4483,
+			name:        "zero config applies defaults",
+			cfg:         &SandboxConfig{},
+			agentName:   "test",
+			wantGroup:   "default",
+			wantPort:    4483,
+			wantEnabled: true,
 		},
 		{
 			name: "global config preserved",
@@ -1453,12 +1457,13 @@ func TestResolveMCPConfig(t *testing.T) {
 					Port:  9999,
 				},
 			},
-			agentName: "test",
-			wantGroup: "custom-group",
-			wantPort:  9999,
+			agentName:   "test",
+			wantGroup:   "custom-group",
+			wantPort:    9999,
+			wantEnabled: true,
 		},
 		{
-			name: "agent override wins",
+			name: "agent override disables MCP",
 			cfg: &SandboxConfig{
 				MCP: domainconfig.MCPConfig{
 					Group: "global-group",
@@ -1466,19 +1471,19 @@ func TestResolveMCPConfig(t *testing.T) {
 				},
 				AgentOverrides: map[string]domainconfig.AgentOverride{
 					"test": {
-						MCP: &domainconfig.MCPConfig{
-							Group: "agent-group",
-							Port:  7777,
+						MCP: &domainconfig.MCPAgentOverride{
+							Enabled: boolPtr(false),
 						},
 					},
 				},
 			},
-			agentName: "test",
-			wantGroup: "agent-group",
-			wantPort:  7777,
+			agentName:   "test",
+			wantGroup:   "global-group",
+			wantPort:    5555,
+			wantEnabled: false,
 		},
 		{
-			name: "empty override does not clear global",
+			name: "empty override does not change enabled",
 			cfg: &SandboxConfig{
 				MCP: domainconfig.MCPConfig{
 					Group: "global-group",
@@ -1486,15 +1491,35 @@ func TestResolveMCPConfig(t *testing.T) {
 				},
 				AgentOverrides: map[string]domainconfig.AgentOverride{
 					"test": {
-						MCP: &domainconfig.MCPConfig{
-							// Empty group and zero port should not clear global values.
+						MCP: &domainconfig.MCPAgentOverride{},
+					},
+				},
+			},
+			agentName:   "test",
+			wantGroup:   "global-group",
+			wantPort:    5555,
+			wantEnabled: true,
+		},
+		{
+			name: "agent override re-enables MCP",
+			cfg: &SandboxConfig{
+				MCP: domainconfig.MCPConfig{
+					Enabled: boolPtr(false),
+					Group:   "global-group",
+					Port:    5555,
+				},
+				AgentOverrides: map[string]domainconfig.AgentOverride{
+					"test": {
+						MCP: &domainconfig.MCPAgentOverride{
+							Enabled: boolPtr(true),
 						},
 					},
 				},
 			},
-			agentName: "test",
-			wantGroup: "global-group",
-			wantPort:  5555,
+			agentName:   "test",
+			wantGroup:   "global-group",
+			wantPort:    5555,
+			wantEnabled: true,
 		},
 		{
 			name: "agent not in map uses global",
@@ -1505,16 +1530,16 @@ func TestResolveMCPConfig(t *testing.T) {
 				},
 				AgentOverrides: map[string]domainconfig.AgentOverride{
 					"other-agent": {
-						MCP: &domainconfig.MCPConfig{
-							Group: "other-group",
-							Port:  8888,
+						MCP: &domainconfig.MCPAgentOverride{
+							Enabled: boolPtr(false),
 						},
 					},
 				},
 			},
-			agentName: "test",
-			wantGroup: "global-group",
-			wantPort:  6666,
+			agentName:   "test",
+			wantGroup:   "global-group",
+			wantPort:    6666,
+			wantEnabled: true,
 		},
 	}
 
@@ -1529,6 +1554,7 @@ func TestResolveMCPConfig(t *testing.T) {
 
 			assert.Equal(t, tt.wantGroup, got.Group)
 			assert.Equal(t, tt.wantPort, got.Port)
+			assert.Equal(t, tt.wantEnabled, got.IsEnabled())
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Replace `AgentOverride.MCP` (`*MCPConfig`) with a new `MCPAgentOverride` type exposing only `Enabled` and `Authz` — makes unsupported fields (`Group`, `Port`, `Config`) unrepresentable at compile time
- Export `MergeMCPAuthzConfig` and add tighten-only per-agent authz merging in the composition root before `VMCPProvider` construction
- Simplify `resolveMCPConfig` to Enabled-only overrides, removing dead Group/Port/Config code that was parsed but never had runtime effect
- Update `warnLocalConfigOverrides` to warn about per-agent `Authz` instead of the removed fields

## Test plan

- [x] `task fmt && task lint` — 0 issues
- [x] `task test` — all tests pass with race detector
- [ ] CI passes (test, lint, build matrix)
- [ ] Manual: config with `agents.claude-code.mcp.authz.profile: observe` parses correctly and the tighter profile propagates

## Backward compatibility

Go's `yaml.v3` silently drops unknown fields. Users with existing per-agent `mcp.group`/`mcp.port`/`mcp.config` in YAML will see those fields silently ignored — same as today since they never had runtime effect. The Go API change (`AgentOverride.MCP` type) is breaking for external consumers, acceptable at v0.0.x.

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)