### PR TITLE
Fix MCP proxy broken by toolhive v0.12.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,40 @@ jobs:
       - name: Build
         run: task build
 
+  integration-test:
+    name: Integration Test (MCP)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Configure Git for private modules
+        run: |
+          git config --global url."https://${{ github.actor }}:${{ secrets.GO_MODULE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Install Task
+        uses: go-task/setup-task@v1
+
+      - name: Build bbox-init (for go:embed)
+        run: task build-init
+
+      - name: Install ToolHive
+        uses: StacklokLabs/toolhive-actions/install@v0
+
+      - name: Run MCP server
+        uses: StacklokLabs/toolhive-actions/run-mcp-server@v0
+        with:
+          server: fetch
+
+      - name: Run integration tests
+        run: go test -v -race -run Integration ./internal/infra/mcp/
+
   images:
     name: Build Images
     runs-on: ubuntu-latest

--- a/internal/infra/mcp/provider.go
+++ b/internal/infra/mcp/provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stacklok/toolhive/pkg/vmcp/discovery"
 	"github.com/stacklok/toolhive/pkg/vmcp/router"
 	vmcpserver "github.com/stacklok/toolhive/pkg/vmcp/server"
+	vmcpsession "github.com/stacklok/toolhive/pkg/vmcp/session"
 	workloadsmgr "github.com/stacklok/toolhive/pkg/workloads"
 
 	domainconfig "github.com/stacklok/brood-box/pkg/domain/config"
@@ -148,6 +149,12 @@ func (p *VMCPProvider) Services(ctx context.Context) ([]hostservice.Service, err
 		return nil, err
 	}
 
+	// Create session factory for vmcp session management.
+	sessionFactory := vmcpsession.NewSessionFactory(
+		authRegistry,
+		vmcpsession.WithAggregator(agg),
+	)
+
 	// Create vmcp server with the resolved auth/authz middleware.
 	srv, err := vmcpserver.New(
 		ctx,
@@ -159,6 +166,7 @@ func (p *VMCPProvider) Services(ctx context.Context) ([]hostservice.Service, err
 			AuthMiddleware:  authMiddleware,
 			AuthzMiddleware: authzMiddleware,
 			AuthInfoHandler: authInfoHandler,
+			SessionFactory:  sessionFactory,
 		},
 		rt,
 		backendClient,

--- a/internal/infra/mcp/provider_integration_test.go
+++ b/internal/infra/mcp/provider_integration_test.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/brood-box/internal/infra/mcp"
+	"github.com/stacklok/brood-box/pkg/domain/config"
+)
+
+// skipIfToolhiveUnavailable skips the test when ToolHive is not installed or
+// has no running servers in the default group.
+func skipIfToolhiveUnavailable(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("thv"); err != nil {
+		t.Skip("thv CLI not found — skipping integration test")
+	}
+
+	cmd := exec.Command("thv", "list", "--format", "json")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Skipf("thv list failed — skipping integration test: %v", err)
+	}
+
+	var servers []json.RawMessage
+	if err := json.Unmarshal(out, &servers); err != nil {
+		t.Skipf("thv list returned invalid JSON — skipping integration test: %s", out)
+	}
+	if len(servers) == 0 {
+		t.Skip("no ToolHive servers running — skipping integration test")
+	}
+}
+
+// TestVMCPProvider_Services_Integration verifies that VMCPProvider.Services
+// can discover backends, build an HTTP handler, and return a valid service
+// when ToolHive is running with at least one server.
+func TestVMCPProvider_Services_Integration(t *testing.T) {
+	skipIfToolhiveUnavailable(t)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	provider := mcp.NewVMCPProvider(
+		"default",  // group
+		4483,       // port
+		nil,        // no custom MCP config
+		nil,        // full-access (no authz restrictions)
+		logger,     // logger
+		io.Discard, // log writer
+	)
+
+	ctx := context.Background()
+	services, err := provider.Services(ctx)
+	require.NoError(t, err, "Services() must not return an error when ToolHive is running")
+	require.Len(t, services, 1, "expected exactly one MCP service")
+
+	svc := services[0]
+	assert.Equal(t, "mcp", svc.Name)
+	assert.Equal(t, uint16(4483), svc.Port)
+	assert.NotNil(t, svc.Handler, "HTTP handler must not be nil")
+
+	// Clean up the vmcp server to avoid leaking goroutines.
+	require.NoError(t, provider.Close())
+}
+
+// TestVMCPProvider_Services_WithAuthzProfiles_Integration verifies that
+// Services succeeds with each built-in authorization profile.
+func TestVMCPProvider_Services_WithAuthzProfiles_Integration(t *testing.T) {
+	skipIfToolhiveUnavailable(t)
+
+	profiles := []string{
+		config.MCPAuthzProfileFullAccess,
+		config.MCPAuthzProfileObserve,
+		config.MCPAuthzProfileSafeTools,
+	}
+
+	for _, profile := range profiles {
+		t.Run(profile, func(t *testing.T) {
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+			provider := mcp.NewVMCPProvider(
+				"default",
+				4483,
+				nil,
+				&config.MCPAuthzConfig{Profile: profile},
+				logger,
+				io.Discard,
+			)
+
+			ctx := context.Background()
+			services, err := provider.Services(ctx)
+			require.NoError(t, err, "Services() must not error with profile %q", profile)
+			require.Len(t, services, 1)
+			assert.NotNil(t, services[0].Handler)
+
+			require.NoError(t, provider.Close())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix**: Toolhive v0.12.2 made `SessionFactory` a required field on `vmcpserver.Config`. The VMCPProvider wasn't setting it, causing `Services()` to fail with `"SessionFactory is required but was not provided"` — surfaced as "MCP unavailable, continuing without MCP support".
- **Integration test**: Add `provider_integration_test.go` that calls `Services()` end-to-end against a live ToolHive instance, covering all built-in authz profiles. Skips gracefully when `thv` is absent or no servers are running.
- **CI job**: New `integration-test` job provisions ToolHive and a fetch MCP server via `toolhive-actions` so the integration test runs on every PR.

## Test plan

- [x] `task test` — all existing tests pass
- [x] `task lint` — no issues
- [x] Manual `bbox claude-code` run confirms MCP tools are discovered
- [x] Integration tests pass locally against running ToolHive
- [ ] CI integration-test job passes with toolhive-actions provisioned server

🤖 Generated with [Claude Code](https://claude.com/claude-code)