### PR TITLE
Fix git commit replay: divergence guard, file permissions, ResolveHEAD

### DIFF
--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -847,6 +847,9 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 				reviewErr = fmt.Errorf("reviewing changes: %w", revErr)
 			} else if len(result.Accepted) > 0 {
 				reviewErr = runner.Flush(sb, result.Accepted)
+				if reviewErr == nil {
+					runner.ReplayCommits(ctx, sb, result.Accepted)
+				}
 			} else {
 				observer.Warn("No changes accepted")
 			}

--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -730,6 +730,7 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 	}
 	deps.Flusher = review.NewFSFlusher()
 	deps.Differ = diff.NewFSDiffer()
+	deps.CommitReplayer = infragit.NewGitCommitReplayer(logger)
 
 	// Wire snapshot post-processors (git config sanitizer).
 	deps.SnapshotPostProcessors = []workspace.SnapshotPostProcessor{

--- a/internal/infra/git/replay.go
+++ b/internal/infra/git/replay.go
@@ -1,0 +1,420 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	infraws "github.com/stacklok/brood-box/internal/infra/workspace"
+	domaingit "github.com/stacklok/brood-box/pkg/domain/git"
+)
+
+// Compile-time interface check.
+var _ domaingit.CommitReplayer = (*GitCommitReplayer)(nil)
+
+// GitCommitReplayer replays commits from a snapshot repository onto the
+// original workspace using git commands.
+type GitCommitReplayer struct {
+	logger *slog.Logger
+}
+
+// NewGitCommitReplayer creates a new GitCommitReplayer.
+func NewGitCommitReplayer(logger *slog.Logger) *GitCommitReplayer {
+	return &GitCommitReplayer{logger: logger}
+}
+
+// commitMeta holds metadata extracted from a single commit.
+type commitMeta struct {
+	AuthorName  string
+	AuthorEmail string
+	AuthorDate  string
+	Message     string
+}
+
+// fileChange represents a single file change in a commit.
+type fileChange struct {
+	Status string // "A", "M", "D", "R", "C", etc.
+	Path   string
+}
+
+// ResolveHEAD returns the current HEAD commit hash for the repo at the given path.
+func (r *GitCommitReplayer) ResolveHEAD(ctx context.Context, repoPath string) (string, error) {
+	out, err := r.gitOutput(ctx, repoPath, "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("resolving HEAD: %w", err)
+	}
+	return out, nil
+}
+
+// Replay extracts new commits from the snapshot's git history and recreates
+// them in the original repo with the same metadata. Only files in the
+// accepted set are included.
+func (r *GitCommitReplayer) Replay(
+	ctx context.Context, originalPath, snapshotPath, baseRef string, accepted []string,
+) (*domaingit.ReplayResult, error) {
+	result := &domaingit.ReplayResult{}
+
+	// Early exit: no base ref means no initial HEAD (e.g. worktree case).
+	if baseRef == "" {
+		r.logger.Debug("no base ref, skipping commit replay")
+		return result, nil
+	}
+
+	// Get current snapshot HEAD.
+	snapshotHEAD, err := r.gitOutput(ctx, snapshotPath, "rev-parse", "HEAD")
+	if err != nil {
+		return result, fmt.Errorf("resolving snapshot HEAD: %w", err)
+	}
+
+	// No new commits.
+	if snapshotHEAD == baseRef {
+		r.logger.Debug("no new commits in snapshot")
+		return result, nil
+	}
+
+	// List new commits oldest-first.
+	commits, err := r.listNewCommits(ctx, snapshotPath, baseRef)
+	if err != nil {
+		return result, fmt.Errorf("listing new commits: %w", err)
+	}
+
+	if len(commits) == 0 {
+		return result, nil
+	}
+
+	// Build accepted set for O(1) lookup.
+	acceptedSet := make(map[string]bool, len(accepted))
+	for _, p := range accepted {
+		acceptedSet[p] = true
+	}
+
+	r.logger.Debug("replaying commits", "count", len(commits), "accepted_files", len(accepted))
+
+	for _, hash := range commits {
+		replayed, err := r.replayCommit(ctx, originalPath, snapshotPath, hash, acceptedSet)
+		if err != nil {
+			r.logger.Warn("failed to replay commit, continuing", "hash", hash, "error", err)
+			result.Skipped++
+			continue
+		}
+		if replayed {
+			result.Replayed++
+		} else {
+			result.Skipped++
+		}
+	}
+
+	// Restore uncommitted state: after replay, the working tree in originalPath
+	// reflects the last replayed commit. We need to restore any files that were
+	// flushed but not part of any commit (uncommitted changes from the snapshot).
+	if err := r.restoreUncommittedChanges(ctx, originalPath, snapshotPath, acceptedSet); err != nil {
+		r.logger.Warn("failed to restore uncommitted changes after replay", "error", err)
+	}
+
+	return result, nil
+}
+
+// replayCommit recreates a single commit in the original repo.
+// Returns true if the commit was replayed, false if skipped.
+func (r *GitCommitReplayer) replayCommit(
+	ctx context.Context, originalPath, snapshotPath, hash string, acceptedSet map[string]bool,
+) (bool, error) {
+	// Skip merge commits (more than one parent).
+	parents, err := r.gitOutput(ctx, snapshotPath, "rev-list", "--parents", "-1", hash)
+	if err != nil {
+		return false, fmt.Errorf("checking parents: %w", err)
+	}
+	parentParts := strings.Fields(parents)
+	if len(parentParts) > 2 { // first field is the commit itself
+		r.logger.Debug("skipping merge commit", "hash", hash)
+		return false, nil
+	}
+
+	// Get commit metadata.
+	meta, err := r.getCommitMeta(ctx, snapshotPath, hash)
+	if err != nil {
+		return false, fmt.Errorf("getting commit metadata: %w", err)
+	}
+
+	// Get changed files.
+	changes, err := r.getCommitFiles(ctx, snapshotPath, hash)
+	if err != nil {
+		return false, fmt.Errorf("getting commit files: %w", err)
+	}
+
+	// Filter to accepted files only.
+	var acceptedChanges []fileChange
+	for _, fc := range changes {
+		if acceptedSet[fc.Path] {
+			acceptedChanges = append(acceptedChanges, fc)
+		}
+	}
+
+	if len(acceptedChanges) == 0 {
+		r.logger.Debug("skipping commit with no accepted files", "hash", hash)
+		return false, nil
+	}
+
+	if len(acceptedChanges) < len(changes) {
+		r.logger.Warn("replaying partial commit (some files were rejected)",
+			"hash", hash, "total", len(changes), "accepted", len(acceptedChanges))
+	}
+
+	// Stage each accepted file change.
+	for _, fc := range acceptedChanges {
+		if err := r.stageFileChange(ctx, originalPath, snapshotPath, hash, fc); err != nil {
+			return false, fmt.Errorf("staging %s (%s): %w", fc.Path, fc.Status, err)
+		}
+	}
+
+	// Check if there are any staged changes before committing.
+	// This avoids creating misleading empty commits when the content
+	// already matches (e.g. the flush already wrote the file).
+	_, diffErr := r.gitOutput(ctx, originalPath, "diff", "--cached", "--quiet")
+	if diffErr == nil {
+		// No staged changes — skip this commit.
+		r.logger.Debug("skipping commit with no effective changes after staging", "hash", hash)
+		return false, nil
+	}
+
+	// Create commit with original metadata.
+	author := fmt.Sprintf("%s <%s>", meta.AuthorName, meta.AuthorEmail)
+	_, err = r.gitOutput(ctx, originalPath,
+		"commit",
+		"--author", author,
+		"--date", meta.AuthorDate,
+		"-m", meta.Message,
+	)
+	if err != nil {
+		return false, fmt.Errorf("creating commit: %w", err)
+	}
+
+	r.logger.Debug("replayed commit", "hash", hash, "files", len(acceptedChanges))
+	return true, nil
+}
+
+// stageFileChange stages a single file change in the original repo.
+func (r *GitCommitReplayer) stageFileChange(
+	ctx context.Context, originalPath, snapshotPath, hash string, fc fileChange,
+) error {
+	// Validate path: must not escape workspace.
+	if err := validatePath(fc.Path); err != nil {
+		return err
+	}
+
+	switch fc.Status {
+	case "D":
+		// File was deleted — remove from index if it exists.
+		_, err := r.gitOutput(ctx, originalPath, "rm", "--cached", "--ignore-unmatch", "--", fc.Path)
+		return err
+
+	default:
+		// Added or modified — extract content from snapshot commit and write to original.
+		content, err := r.getFileAtCommit(ctx, snapshotPath, hash, fc.Path)
+		if err != nil {
+			return fmt.Errorf("reading file content: %w", err)
+		}
+
+		destPath := filepath.Join(originalPath, fc.Path)
+
+		// Symlink-aware bounds check (matches flusher's defense-in-depth).
+		if err := infraws.ValidateInBounds(originalPath, destPath); err != nil {
+			return fmt.Errorf("path traversal rejected for %s: %w", fc.Path, err)
+		}
+
+		// Ensure parent directory exists.
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+			return fmt.Errorf("creating parent dir: %w", err)
+		}
+
+		if err := os.WriteFile(destPath, content, 0o644); err != nil {
+			return fmt.Errorf("writing file: %w", err)
+		}
+
+		_, err = r.gitOutput(ctx, originalPath, "add", "--", fc.Path)
+		return err
+	}
+}
+
+// restoreUncommittedChanges copies the final working tree state from the
+// snapshot for any accepted files, undoing intermediate states written
+// during commit replay.
+func (r *GitCommitReplayer) restoreUncommittedChanges(
+	ctx context.Context, originalPath, snapshotPath string, acceptedSet map[string]bool,
+) error {
+	for path := range acceptedSet {
+		if err := validatePath(path); err != nil {
+			continue
+		}
+
+		srcPath := filepath.Join(snapshotPath, path)
+		destPath := filepath.Join(originalPath, path)
+
+		// Symlink-aware bounds check.
+		if err := infraws.ValidateInBounds(originalPath, destPath); err != nil {
+			r.logger.Warn("skipping file with out-of-bounds path", "path", path, "error", err)
+			continue
+		}
+
+		srcInfo, err := os.Lstat(srcPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// File was deleted in snapshot — ensure it's deleted in original too.
+				_ = os.Remove(destPath)
+				continue
+			}
+			return fmt.Errorf("stat %s in snapshot: %w", path, err)
+		}
+
+		// Skip non-regular files.
+		if !srcInfo.Mode().IsRegular() {
+			continue
+		}
+
+		content, err := os.ReadFile(srcPath)
+		if err != nil {
+			return fmt.Errorf("reading %s from snapshot: %w", path, err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+			return fmt.Errorf("creating parent dir for %s: %w", path, err)
+		}
+
+		if err := os.WriteFile(destPath, content, srcInfo.Mode().Perm()); err != nil {
+			return fmt.Errorf("writing %s to original: %w", path, err)
+		}
+	}
+
+	// Reset the index to match the working tree so we don't leave staged changes.
+	_, err := r.gitOutput(ctx, originalPath, "reset")
+	if err != nil {
+		r.logger.Debug("failed to reset index after restoring uncommitted changes", "error", err)
+	}
+
+	return nil
+}
+
+// listNewCommits returns commit hashes between baseRef and HEAD, oldest first.
+func (r *GitCommitReplayer) listNewCommits(ctx context.Context, repoPath, baseRef string) ([]string, error) {
+	out, err := r.gitOutput(ctx, repoPath, "rev-list", "--reverse", baseRef+"..HEAD")
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
+}
+
+// getCommitMeta extracts author name, email, date, and message from a commit.
+func (r *GitCommitReplayer) getCommitMeta(ctx context.Context, repoPath, hash string) (commitMeta, error) {
+	// Format: author name, author email, author date (ISO), commit message body
+	out, err := r.gitOutput(ctx, repoPath, "log", "-1", "--format=%an%n%ae%n%aI%n%B", hash)
+	if err != nil {
+		return commitMeta{}, err
+	}
+
+	lines := strings.SplitN(out, "\n", 4)
+	if len(lines) < 4 {
+		return commitMeta{}, fmt.Errorf("unexpected log format for %s: got %d lines", hash, len(lines))
+	}
+
+	return commitMeta{
+		AuthorName:  lines[0],
+		AuthorEmail: lines[1],
+		AuthorDate:  lines[2],
+		Message:     strings.TrimRight(lines[3], "\n"),
+	}, nil
+}
+
+// getCommitFiles returns the list of changed files in a commit.
+func (r *GitCommitReplayer) getCommitFiles(ctx context.Context, repoPath, hash string) ([]fileChange, error) {
+	out, err := r.gitOutput(ctx, repoPath, "diff-tree", "--no-commit-id", "--name-status", "-r", hash)
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+
+	var changes []fileChange
+	for _, line := range strings.Split(out, "\n") {
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		status := parts[0]
+		path := parts[1]
+
+		// For rename/copy, diff-tree outputs "R100\told\tnew".
+		// Emit two changes: delete old path + add new path for renames,
+		// or just add new path for copies.
+		if strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C") {
+			paths := strings.SplitN(parts[1], "\t", 2)
+			if len(paths) == 2 {
+				if strings.HasPrefix(status, "R") {
+					// Rename: delete old path.
+					changes = append(changes, fileChange{Status: "D", Path: paths[0]})
+				}
+				// Add new path.
+				changes = append(changes, fileChange{Status: "A", Path: paths[1]})
+				continue
+			}
+		}
+
+		changes = append(changes, fileChange{Status: status, Path: path})
+	}
+
+	return changes, nil
+}
+
+// getFileAtCommit extracts file content at a specific commit.
+func (r *GitCommitReplayer) getFileAtCommit(ctx context.Context, repoPath, hash, path string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "show", hash+":"+path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git show %s:%s: %w: %s", hash, path, err, stderr.String())
+	}
+	return stdout.Bytes(), nil
+}
+
+// gitOutput runs a git command and returns trimmed stdout.
+func (r *GitCommitReplayer) gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr.String())
+	}
+	return strings.TrimRight(stdout.String(), "\n"), nil
+}
+
+// validatePath rejects paths that could escape the workspace.
+func validatePath(path string) error {
+	if path == "" {
+		return fmt.Errorf("empty path")
+	}
+	if filepath.IsAbs(path) {
+		return fmt.Errorf("absolute path not allowed: %s", path)
+	}
+	cleaned := filepath.Clean(path)
+	if strings.HasPrefix(cleaned, "..") {
+		return fmt.Errorf("path traversal not allowed: %s", path)
+	}
+	// Block .git directory manipulation.
+	if cleaned == ".git" || strings.HasPrefix(cleaned, ".git/") || strings.HasPrefix(cleaned, ".git\\") {
+		return fmt.Errorf("path inside .git not allowed: %s", path)
+	}
+	return nil
+}

--- a/internal/infra/git/replay.go
+++ b/internal/infra/git/replay.go
@@ -46,10 +46,13 @@ type fileChange struct {
 }
 
 // ResolveHEAD returns the current HEAD commit hash for the repo at the given path.
+// Returns an empty string (not an error) if the repo has no commits or is not a git repository.
 func (r *GitCommitReplayer) ResolveHEAD(ctx context.Context, repoPath string) (string, error) {
 	out, err := r.gitOutput(ctx, repoPath, "rev-parse", "HEAD")
 	if err != nil {
-		return "", fmt.Errorf("resolving HEAD: %w", err)
+		// No commits or not a git repo — return empty per interface contract.
+		r.logger.Debug("could not resolve HEAD", "path", repoPath, "error", err)
+		return "", nil
 	}
 	return out, nil
 }
@@ -77,6 +80,20 @@ func (r *GitCommitReplayer) Replay(
 	// No new commits.
 	if snapshotHEAD == baseRef {
 		r.logger.Debug("no new commits in snapshot")
+		return result, nil
+	}
+
+	// Guard: ensure the original repo's HEAD hasn't moved since snapshot creation.
+	originalHEAD, origErr := r.gitOutput(ctx, originalPath, "rev-parse", "HEAD")
+	if origErr != nil {
+		r.logger.Warn("could not resolve original HEAD, skipping replay", "error", origErr)
+		result.Diverged = true
+		return result, nil
+	}
+	if originalHEAD != baseRef {
+		r.logger.Warn("original repo HEAD has diverged, skipping commit replay",
+			"original_head", originalHEAD, "base_ref", baseRef)
+		result.Diverged = true
 		return result, nil
 	}
 
@@ -235,8 +252,14 @@ func (r *GitCommitReplayer) stageFileChange(
 			return fmt.Errorf("creating parent dir: %w", err)
 		}
 
-		if err := os.WriteFile(destPath, content, 0o644); err != nil {
+		fileMode := r.getFileModeAtCommit(ctx, snapshotPath, hash, fc.Path)
+		if err := os.WriteFile(destPath, content, fileMode); err != nil {
 			return fmt.Errorf("writing file: %w", err)
+		}
+		// WriteFile only applies mode on creation; chmod ensures correct
+		// permissions when the file already exists (e.g. from flush).
+		if err := os.Chmod(destPath, fileMode); err != nil {
+			return fmt.Errorf("setting file mode: %w", err)
 		}
 
 		_, err = r.gitOutput(ctx, originalPath, "add", "--", fc.Path)
@@ -374,6 +397,26 @@ func (r *GitCommitReplayer) getCommitFiles(ctx context.Context, repoPath, hash s
 	}
 
 	return changes, nil
+}
+
+// getFileModeAtCommit returns the file permission for a path at a specific commit.
+// Uses git ls-tree to query the tree mode. Returns 0o755 for executable files
+// (mode 100755), 0o644 for everything else. Falls back to 0o644 on failure.
+func (r *GitCommitReplayer) getFileModeAtCommit(
+	ctx context.Context, repoPath, hash, path string,
+) os.FileMode {
+	out, err := r.gitOutput(ctx, repoPath, "ls-tree", hash, "--", path)
+	if err != nil {
+		r.logger.Debug("could not query file mode, using default",
+			"hash", hash, "path", path, "error", err)
+		return 0o644
+	}
+	// Output: "<mode> <type> <hash>\t<path>"
+	fields := strings.Fields(out)
+	if len(fields) >= 1 && fields[0] == "100755" {
+		return 0o755
+	}
+	return 0o644
 }
 
 // getFileAtCommit extracts file content at a specific commit.

--- a/internal/infra/git/replay_test.go
+++ b/internal/infra/git/replay_test.go
@@ -1,0 +1,431 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initRepo creates a git repo at the given path with an initial commit.
+func initRepo(t *testing.T, path string) {
+	t.Helper()
+	run(t, path, "git", "init")
+	run(t, path, "git", "config", "user.name", "Test Author")
+	run(t, path, "git", "config", "user.email", "test@example.com")
+	writeFile(t, filepath.Join(path, "README.md"), "# Test\n")
+	run(t, path, "git", "add", "README.md")
+	run(t, path, "git", "commit", "-m", "Initial commit")
+}
+
+// run executes a command in the given directory.
+func run(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v failed in %s: %v\n%s", name, args, dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// writeFile writes content to a file, creating parent dirs as needed.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// getHEAD returns the HEAD commit hash of a repo.
+func getHEAD(t *testing.T, dir string) string {
+	t.Helper()
+	return run(t, dir, "git", "rev-parse", "HEAD")
+}
+
+// newTestReplayer creates a GitCommitReplayer with a discard logger.
+func newTestReplayer() *GitCommitReplayer {
+	return NewGitCommitReplayer(slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestReplay_NoNewCommits(t *testing.T) {
+	t.Parallel()
+
+	snapshot := t.TempDir()
+	original := t.TempDir()
+
+	initRepo(t, snapshot)
+	baseRef := getHEAD(t, snapshot)
+
+	initRepo(t, original)
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Replayed != 0 || result.Skipped != 0 {
+		t.Errorf("expected 0 replayed/skipped, got %d/%d", result.Replayed, result.Skipped)
+	}
+}
+
+func TestReplay_EmptyBaseRef(t *testing.T) {
+	t.Parallel()
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), "/tmp", "/tmp", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Replayed != 0 {
+		t.Errorf("expected 0 replayed, got %d", result.Replayed)
+	}
+}
+
+func TestReplay_SingleCommit(t *testing.T) {
+	t.Parallel()
+
+	// Set up snapshot repo with an initial commit.
+	snapshot := t.TempDir()
+	initRepo(t, snapshot)
+	baseRef := getHEAD(t, snapshot)
+
+	// Clone snapshot to simulate original (same initial state).
+	original := t.TempDir()
+	run(t, "", "git", "clone", snapshot, original)
+	run(t, original, "git", "config", "user.name", "Test Author")
+	run(t, original, "git", "config", "user.email", "test@example.com")
+
+	// Make a commit in the snapshot.
+	writeFile(t, filepath.Join(snapshot, "new.txt"), "hello world\n")
+	run(t, snapshot, "git", "add", "new.txt")
+	run(t, snapshot, "git", "commit", "-m", "Add new file")
+
+	// Also write the file to the original to simulate flush.
+	writeFile(t, filepath.Join(original, "new.txt"), "hello world\n")
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"new.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Replayed != 1 {
+		t.Errorf("expected 1 replayed, got %d", result.Replayed)
+	}
+
+	// Verify the commit exists in original.
+	logOut := run(t, original, "git", "log", "--oneline")
+	if !strings.Contains(logOut, "Add new file") {
+		t.Errorf("expected 'Add new file' in git log, got:\n%s", logOut)
+	}
+
+	// Verify the file content is correct (restored from flush).
+	content, err := os.ReadFile(filepath.Join(original, "new.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "hello world\n" {
+		t.Errorf("expected 'hello world\\n', got %q", content)
+	}
+}
+
+func TestReplay_MultipleCommits(t *testing.T) {
+	t.Parallel()
+
+	snapshot := t.TempDir()
+	initRepo(t, snapshot)
+	baseRef := getHEAD(t, snapshot)
+
+	original := t.TempDir()
+	run(t, "", "git", "clone", snapshot, original)
+	run(t, original, "git", "config", "user.name", "Test Author")
+	run(t, original, "git", "config", "user.email", "test@example.com")
+
+	// First commit in snapshot.
+	writeFile(t, filepath.Join(snapshot, "a.txt"), "aaa\n")
+	run(t, snapshot, "git", "add", "a.txt")
+	run(t, snapshot, "git", "commit", "-m", "Add a")
+
+	// Second commit in snapshot.
+	writeFile(t, filepath.Join(snapshot, "b.txt"), "bbb\n")
+	run(t, snapshot, "git", "add", "b.txt")
+	run(t, snapshot, "git", "commit", "-m", "Add b")
+
+	// Simulate flush: write final state to original.
+	writeFile(t, filepath.Join(original, "a.txt"), "aaa\n")
+	writeFile(t, filepath.Join(original, "b.txt"), "bbb\n")
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"a.txt", "b.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Replayed != 2 {
+		t.Errorf("expected 2 replayed, got %d", result.Replayed)
+	}
+
+	// Verify commit order.
+	logOut := run(t, original, "git", "log", "--oneline")
+	lines := strings.Split(strings.TrimSpace(logOut), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 commits, got:\n%s", logOut)
+	}
+	// Most recent should be "Add b".
+	if !strings.Contains(lines[0], "Add b") {
+		t.Errorf("expected first line to contain 'Add b', got %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "Add a") {
+		t.Errorf("expected second line to contain 'Add a', got %q", lines[1])
+	}
+}
+
+func TestReplay_PartialAcceptance(t *testing.T) {
+	t.Parallel()
+
+	snapshot := t.TempDir()
+	initRepo(t, snapshot)
+	baseRef := getHEAD(t, snapshot)
+
+	original := t.TempDir()
+	run(t, "", "git", "clone", snapshot, original)
+	run(t, original, "git", "config", "user.name", "Test Author")
+	run(t, original, "git", "config", "user.email", "test@example.com")
+
+	// Commit that touches two files.
+	writeFile(t, filepath.Join(snapshot, "accepted.txt"), "yes\n")
+	writeFile(t, filepath.Join(snapshot, "rejected.txt"), "no\n")
+	run(t, snapshot, "git", "add", "accepted.txt", "rejected.txt")
+	run(t, snapshot, "git", "commit", "-m", "Add two files")
+
+	// Only flush accepted file.
+	writeFile(t, filepath.Join(original, "accepted.txt"), "yes\n")
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"accepted.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Replayed != 1 {
+		t.Errorf("expected 1 replayed, got %d", result.Replayed)
+	}
+
+	// Verify only accepted.txt is in the commit.
+	showOut := run(t, original, "git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD")
+	if strings.TrimSpace(showOut) != "accepted.txt" {
+		t.Errorf("expected only accepted.txt in commit, got %q", showOut)
+	}
+}
+
+func TestReplay_CommitWithNoAcceptedFiles(t *testing.T) {
+	t.Parallel()
+
+	snapshot := t.TempDir()
+	initRepo(t, snapshot)
+	baseRef := getHEAD(t, snapshot)
+
+	original := t.TempDir()
+	run(t, "", "git", "clone", snapshot, original)
+	run(t, original, "git", "config", "user.name", "Test Author")
+	run(t, original, "git", "config", "user.email", "test@example.com")
+
+	// Add a file that won't be accepted.
+	writeFile(t, filepath.Join(snapshot, "rejected.txt"), "no\n")
+	run(t, snapshot, "git", "add", "rejected.txt")
+	run(t, snapshot, "git", "commit", "-m", "Add rejected file")
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"other.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Replayed != 0 {
+		t.Errorf("expected 0 replayed, got %d", result.Replayed)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("expected 1 skipped, got %d", result.Skipped)
+	}
+}
+
+func TestReplay_FileDeletion(t *testing.T) {
+	t.Parallel()
+
+	snapshot := t.TempDir()
+	initRepo(t, snapshot)
+
+	// Add a file to delete later.
+	writeFile(t, filepath.Join(snapshot, "deleteme.txt"), "bye\n")
+	run(t, snapshot, "git", "add", "deleteme.txt")
+	run(t, snapshot, "git", "commit", "-m", "Add file to delete")
+	baseRef := getHEAD(t, snapshot)
+
+	original := t.TempDir()
+	run(t, "", "git", "clone", snapshot, original)
+	run(t, original, "git", "config", "user.name", "Test Author")
+	run(t, original, "git", "config", "user.email", "test@example.com")
+
+	// Delete the file in snapshot.
+	run(t, snapshot, "git", "rm", "deleteme.txt")
+	run(t, snapshot, "git", "commit", "-m", "Delete file")
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"deleteme.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Replayed != 1 {
+		t.Errorf("expected 1 replayed, got %d", result.Replayed)
+	}
+}
+
+func TestReplay_MergeCommitSkipped(t *testing.T) {
+	t.Parallel()
+
+	snapshot := t.TempDir()
+	initRepo(t, snapshot)
+	baseRef := getHEAD(t, snapshot)
+
+	// Create a branch, make a commit, merge.
+	defaultBranch := run(t, snapshot, "git", "branch", "--show-current")
+	run(t, snapshot, "git", "checkout", "-b", "feature")
+	writeFile(t, filepath.Join(snapshot, "feature.txt"), "feat\n")
+	run(t, snapshot, "git", "add", "feature.txt")
+	run(t, snapshot, "git", "commit", "-m", "Feature commit")
+
+	run(t, snapshot, "git", "checkout", defaultBranch)
+	writeFile(t, filepath.Join(snapshot, "main.txt"), "main\n")
+	run(t, snapshot, "git", "add", "main.txt")
+	run(t, snapshot, "git", "commit", "-m", "Main commit")
+
+	run(t, snapshot, "git", "merge", "feature", "--no-edit")
+
+	original := t.TempDir()
+	initRepo(t, original)
+
+	// Simulate flush.
+	writeFile(t, filepath.Join(original, "feature.txt"), "feat\n")
+	writeFile(t, filepath.Join(original, "main.txt"), "main\n")
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"feature.txt", "main.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The merge commit should be skipped, but the regular commits should be replayed.
+	if result.Skipped < 1 {
+		t.Errorf("expected at least 1 skipped (merge commit), got %d", result.Skipped)
+	}
+}
+
+func TestReplay_PreservesAuthorMetadata(t *testing.T) {
+	t.Parallel()
+
+	snapshot := t.TempDir()
+	initRepo(t, snapshot)
+	baseRef := getHEAD(t, snapshot)
+
+	original := t.TempDir()
+	run(t, "", "git", "clone", snapshot, original)
+	run(t, original, "git", "config", "user.name", "Test Author")
+	run(t, original, "git", "config", "user.email", "test@example.com")
+
+	// Make a commit with specific author.
+	writeFile(t, filepath.Join(snapshot, "authored.txt"), "content\n")
+	run(t, snapshot, "git", "add", "authored.txt")
+	run(t, snapshot, "git", "commit", "--author", "Agent Bot <agent@bot.com>", "-m", "Agent commit")
+
+	writeFile(t, filepath.Join(original, "authored.txt"), "content\n")
+
+	replayer := newTestReplayer()
+	_, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"authored.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check author of HEAD commit in original.
+	author := run(t, original, "git", "log", "-1", "--format=%an <%ae>")
+	if author != "Agent Bot <agent@bot.com>" {
+		t.Errorf("expected author 'Agent Bot <agent@bot.com>', got %q", author)
+	}
+}
+
+func TestReplay_UncommittedChangesRestored(t *testing.T) {
+	t.Parallel()
+
+	snapshot := t.TempDir()
+	initRepo(t, snapshot)
+	baseRef := getHEAD(t, snapshot)
+
+	original := t.TempDir()
+	run(t, "", "git", "clone", snapshot, original)
+	run(t, original, "git", "config", "user.name", "Test Author")
+	run(t, original, "git", "config", "user.email", "test@example.com")
+
+	// Make a commit that modifies a file.
+	writeFile(t, filepath.Join(snapshot, "file.txt"), "committed version\n")
+	run(t, snapshot, "git", "add", "file.txt")
+	run(t, snapshot, "git", "commit", "-m", "Add file")
+
+	// Then modify the file further without committing (uncommitted changes).
+	writeFile(t, filepath.Join(snapshot, "file.txt"), "uncommitted version\n")
+
+	// Simulate flush: original has the final (uncommitted) state.
+	writeFile(t, filepath.Join(original, "file.txt"), "uncommitted version\n")
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"file.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Replayed != 1 {
+		t.Errorf("expected 1 replayed, got %d", result.Replayed)
+	}
+
+	// The working tree should have the uncommitted version restored.
+	content, err := os.ReadFile(filepath.Join(original, "file.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "uncommitted version\n" {
+		t.Errorf("expected uncommitted version, got %q", content)
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"valid relative", "src/main.go", false},
+		{"valid simple", "file.txt", false},
+		{"empty", "", true},
+		{"absolute", "/etc/passwd", true},
+		{"parent traversal", "../escape", true},
+		{"deep traversal", "foo/../../escape", true},
+		{"dot-git exact", ".git", true},
+		{"dot-git subpath", ".git/hooks/pre-commit", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validatePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePath(%q) err=%v, wantErr=%v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/infra/git/replay_test.go
+++ b/internal/infra/git/replay_test.go
@@ -401,6 +401,152 @@ func TestReplay_UncommittedChangesRestored(t *testing.T) {
 	}
 }
 
+func TestResolveHEAD_NoCommits(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	run(t, dir, "git", "init")
+
+	replayer := newTestReplayer()
+	head, err := replayer.ResolveHEAD(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if head != "" {
+		t.Errorf("expected empty HEAD for repo with no commits, got %q", head)
+	}
+}
+
+func TestReplay_HeadDiverged(t *testing.T) {
+	t.Parallel()
+
+	// Create a common bare repo to clone from so both repos share the same initial commit.
+	bare := t.TempDir()
+	run(t, bare, "git", "init", "--bare")
+
+	snapshot := t.TempDir()
+	run(t, "", "git", "clone", bare, snapshot)
+	run(t, snapshot, "git", "config", "user.name", "Test Author")
+	run(t, snapshot, "git", "config", "user.email", "test@example.com")
+	writeFile(t, filepath.Join(snapshot, "README.md"), "# Test\n")
+	run(t, snapshot, "git", "add", "README.md")
+	run(t, snapshot, "git", "commit", "-m", "Initial commit")
+	run(t, snapshot, "git", "push", "-u", "origin", "HEAD")
+
+	baseRef := getHEAD(t, snapshot)
+
+	original := t.TempDir()
+	run(t, "", "git", "clone", bare, original)
+	run(t, original, "git", "config", "user.name", "Test Author")
+	run(t, original, "git", "config", "user.email", "test@example.com")
+
+	// Simulate agent work in snapshot.
+	writeFile(t, filepath.Join(snapshot, "agent.txt"), "agent work\n")
+	run(t, snapshot, "git", "add", "agent.txt")
+	run(t, snapshot, "git", "commit", "-m", "Agent work")
+
+	// Simulate divergence: someone commits to the original while VM was running.
+	writeFile(t, filepath.Join(original, "other.txt"), "other work\n")
+	run(t, original, "git", "add", "other.txt")
+	run(t, original, "git", "commit", "-m", "Concurrent work")
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"agent.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Diverged {
+		t.Error("expected Diverged=true")
+	}
+	if result.Replayed != 0 {
+		t.Errorf("expected 0 replayed, got %d", result.Replayed)
+	}
+}
+
+func TestReplay_PreservesExecutableBit(t *testing.T) {
+	t.Parallel()
+
+	snapshot := t.TempDir()
+	initRepo(t, snapshot)
+	baseRef := getHEAD(t, snapshot)
+
+	original := t.TempDir()
+	run(t, "", "git", "clone", snapshot, original)
+	run(t, original, "git", "config", "user.name", "Test Author")
+	run(t, original, "git", "config", "user.email", "test@example.com")
+
+	// Create an executable file in the snapshot.
+	scriptPath := filepath.Join(snapshot, "script.sh")
+	writeFile(t, scriptPath, "#!/bin/sh\necho hello\n")
+	if err := os.Chmod(scriptPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, snapshot, "git", "add", "script.sh")
+	run(t, snapshot, "git", "update-index", "--chmod=+x", "script.sh")
+	run(t, snapshot, "git", "commit", "-m", "Add executable script")
+
+	// Simulate flush.
+	writeFile(t, filepath.Join(original, "script.sh"), "#!/bin/sh\necho hello\n")
+
+	replayer := newTestReplayer()
+	result, err := replayer.Replay(context.Background(), original, snapshot, baseRef, []string{"script.sh"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Replayed != 1 {
+		t.Errorf("expected 1 replayed, got %d", result.Replayed)
+	}
+
+	// Verify the file has executable permission.
+	info, err := os.Stat(filepath.Join(original, "script.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("expected executable bit set, got mode %o", info.Mode().Perm())
+	}
+}
+
+func TestGetFileModeAtCommit(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	initRepo(t, repo)
+
+	// Add a regular file and an executable file.
+	writeFile(t, filepath.Join(repo, "regular.txt"), "content\n")
+	run(t, repo, "git", "add", "regular.txt")
+
+	writeFile(t, filepath.Join(repo, "exec.sh"), "#!/bin/sh\n")
+	run(t, repo, "git", "add", "exec.sh")
+	run(t, repo, "git", "update-index", "--chmod=+x", "exec.sh")
+
+	run(t, repo, "git", "commit", "-m", "Add files")
+	hash := getHEAD(t, repo)
+
+	replayer := newTestReplayer()
+
+	tests := []struct {
+		name     string
+		path     string
+		wantMode os.FileMode
+	}{
+		{"regular file", "regular.txt", 0o644},
+		{"executable file", "exec.sh", 0o755},
+		{"nonexistent file", "nosuchfile.txt", 0o644},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mode := replayer.getFileModeAtCommit(context.Background(), repo, hash, tt.path)
+			if mode != tt.wantMode {
+				t.Errorf("getFileModeAtCommit(%q) = %o, want %o", tt.path, mode, tt.wantMode)
+			}
+		})
+	}
+}
+
 func TestValidatePath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/domain/git/replay.go
+++ b/pkg/domain/git/replay.go
@@ -29,4 +29,7 @@ type ReplayResult struct {
 	Replayed int
 	// Skipped is the number of commits that were skipped (e.g. no accepted files, merge commits).
 	Skipped int
+	// Diverged is true when the original repo's HEAD has moved since the
+	// snapshot was taken. Replay is skipped to avoid misleading history.
+	Diverged bool
 }

--- a/pkg/domain/git/replay.go
+++ b/pkg/domain/git/replay.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package git
+
+import "context"
+
+// CommitReplayer replays commits from a snapshot repository onto the original.
+type CommitReplayer interface {
+	// ResolveHEAD returns the current HEAD commit hash for the repo at
+	// the given path. Returns an empty string (not an error) if the
+	// repo has no commits or is not a git repository.
+	ResolveHEAD(ctx context.Context, repoPath string) (string, error)
+
+	// Replay extracts new commits (after baseRef) from the snapshot repo
+	// and recreates them in the original repo using the same metadata.
+	// Only files in the accepted list are included in replayed commits.
+	// Returns the count of replayed and skipped commits.
+	//
+	// baseRef is the HEAD commit hash recorded before the VM started.
+	// An empty baseRef means no initial HEAD existed (e.g. worktree case)
+	// and replay is skipped.
+	Replay(ctx context.Context, originalPath, snapshotPath, baseRef string, accepted []string) (*ReplayResult, error)
+}
+
+// ReplayResult holds the outcome of a commit replay operation.
+type ReplayResult struct {
+	// Replayed is the number of commits successfully recreated.
+	Replayed int
+	// Skipped is the number of commits that were skipped (e.g. no accepted files, merge commits).
+	Skipped int
+}

--- a/pkg/domain/progress/observer.go
+++ b/pkg/domain/progress/observer.go
@@ -23,6 +23,8 @@ const (
 	PhaseComputingDiff
 	// PhaseFlushingChanges is the accepted-changes flush phase.
 	PhaseFlushingChanges
+	// PhaseReplayingCommits is the git commit replay phase.
+	PhaseReplayingCommits
 	// PhaseConfiguringMCP is the MCP proxy configuration phase.
 	PhaseConfiguringMCP
 	// PhaseSavingCredentials is the credential persistence phase.

--- a/pkg/domain/workspace/workspace.go
+++ b/pkg/domain/workspace/workspace.go
@@ -19,6 +19,10 @@ type Snapshot struct {
 	// SnapshotPath is the COW clone directory.
 	SnapshotPath string
 
+	// BaseRef is the HEAD commit hash at snapshot creation time.
+	// Empty if the snapshot has no commits (e.g. worktree case).
+	BaseRef string
+
 	// Cleanup removes the snapshot directory. Set by the WorkspaceCloner
 	// implementation. Safe to call multiple times.
 	Cleanup func() error

--- a/pkg/runtime/factory.go
+++ b/pkg/runtime/factory.go
@@ -69,6 +69,9 @@ type DefaultSandboxDepsOpts struct {
 	// Defaults to ~/.cache/broodbox/snapshots/ (XDG_CACHE_HOME), falling
 	// back to os.TempDir() if XDG resolution fails.
 	SnapshotDir string
+
+	// CommitReplayer overrides the git commit replayer (nil = auto-create default).
+	CommitReplayer domaingit.CommitReplayer
 }
 
 // NewDefaultSandboxDeps wires Brood Box's standard infrastructure dependencies.
@@ -138,7 +141,16 @@ func NewDefaultSandboxDeps(opts DefaultSandboxDepsOpts) sandbox.SandboxDeps {
 		MCPProvider:            opts.MCPProvider,
 		SnapshotPostProcessors: opts.SnapshotPostProcessors,
 		GitIdentityProvider:    gitIdentityProvider,
+		CommitReplayer:         resolveCommitReplayer(opts.CommitReplayer, logger),
 	}
+}
+
+// resolveCommitReplayer returns the provided replayer or creates a default one.
+func resolveCommitReplayer(override domaingit.CommitReplayer, logger *slog.Logger) domaingit.CommitReplayer {
+	if override != nil {
+		return override
+	}
+	return infragit.NewGitCommitReplayer(logger)
 }
 
 // NewDefaultSandboxRunner constructs a SandboxRunner using default infra wiring.

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -143,6 +143,9 @@ type SandboxDeps struct {
 
 	// GitIdentityProvider resolves the host git user identity.
 	GitIdentityProvider domaingit.IdentityProvider
+
+	// CommitReplayer replays git commits from the snapshot to the original workspace (nil = disabled).
+	CommitReplayer domaingit.CommitReplayer
 }
 
 // Sandbox holds the state of a running sandbox session.
@@ -192,6 +195,7 @@ type SandboxRunner struct {
 	mcpProvider            hostservice.Provider
 	snapshotPostProcessors []workspace.SnapshotPostProcessor
 	gitIdentityProvider    domaingit.IdentityProvider
+	commitReplayer         domaingit.CommitReplayer
 }
 
 // NewSandboxRunner creates a new SandboxRunner with the given dependencies.
@@ -216,6 +220,7 @@ func NewSandboxRunner(deps SandboxDeps) *SandboxRunner {
 		mcpProvider:            deps.MCPProvider,
 		snapshotPostProcessors: deps.SnapshotPostProcessors,
 		gitIdentityProvider:    deps.GitIdentityProvider,
+		commitReplayer:         deps.CommitReplayer,
 	}
 }
 
@@ -448,6 +453,15 @@ func (s *SandboxRunner) Prepare(ctx context.Context, agentName string, opts RunO
 			}
 		}
 
+		// Record the snapshot's HEAD so commit replay can detect new commits.
+		if s.commitReplayer != nil {
+			baseRef, refErr := s.commitReplayer.ResolveHEAD(ctx, snap.SnapshotPath)
+			if refErr != nil {
+				s.logger.Debug("could not record snapshot base ref", "error", refErr)
+			}
+			snap.BaseRef = baseRef
+		}
+
 		workspacePath = snap.SnapshotPath
 	}
 
@@ -592,6 +606,40 @@ func (s *SandboxRunner) Flush(sb *Sandbox, accepted []snapshot.FileChange) error
 	return nil
 }
 
+// ReplayCommits replays git commits from the snapshot onto the original workspace.
+// This is a best-effort operation — errors are logged but do not fail the pipeline.
+// Must be called after Flush so the working tree is already correct.
+func (s *SandboxRunner) ReplayCommits(ctx context.Context, sb *Sandbox, accepted []snapshot.FileChange) {
+	if sb.Snapshot == nil || s.commitReplayer == nil {
+		return
+	}
+	if sb.Snapshot.BaseRef == "" {
+		s.logger.Debug("no base ref recorded, skipping commit replay")
+		return
+	}
+
+	s.observer.Start(progress.PhaseReplayingCommits, "Replaying git commits...")
+
+	// Extract accepted file paths.
+	paths := make([]string, 0, len(accepted))
+	for _, fc := range accepted {
+		paths = append(paths, fc.RelPath)
+	}
+
+	result, err := s.commitReplayer.Replay(ctx, sb.Snapshot.OriginalPath, sb.Snapshot.SnapshotPath, sb.Snapshot.BaseRef, paths)
+	if err != nil {
+		s.observer.Warn(fmt.Sprintf("Commit replay failed: %v", err))
+		s.logger.Warn("commit replay failed", "error", err)
+		return
+	}
+
+	if result.Replayed == 0 {
+		s.observer.Complete("No commits to replay")
+	} else {
+		s.observer.Complete(fmt.Sprintf("Replayed %d commit(s), skipped %d", result.Replayed, result.Skipped))
+	}
+}
+
 // Run executes the full sandbox lifecycle for the named agent:
 // Prepare -> Attach -> Stop -> review/flush -> Cleanup.
 // opts.Terminal must be set to provide I/O streams for the session.
@@ -631,6 +679,9 @@ func (s *SandboxRunner) Run(ctx context.Context, agentName string, opts RunOpts)
 				reviewErr = fmt.Errorf("reviewing changes: %w", revErr)
 			} else if len(result.Accepted) > 0 {
 				reviewErr = s.Flush(sb, result.Accepted)
+				if reviewErr == nil {
+					s.ReplayCommits(ctx, sb, result.Accepted)
+				}
 			} else {
 				s.observer.Warn("No changes accepted")
 			}

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -633,6 +633,11 @@ func (s *SandboxRunner) ReplayCommits(ctx context.Context, sb *Sandbox, accepted
 		return
 	}
 
+	if result.Diverged {
+		s.observer.Warn("Skipped commit replay: original repo HEAD diverged during VM session")
+		return
+	}
+
 	if result.Replayed == 0 {
 		s.observer.Complete("No commits to replay")
 	} else {


### PR DESCRIPTION
## Summary

- Add git commit replay feature that replays agent commits from the snapshot back onto the original workspace after flush, preserving author metadata and commit history
- Add HEAD divergence guard — if the original repo's HEAD moves while the VM runs, replay is skipped to avoid misleading ancestry
- Preserve executable file permissions (`0o755`) in replayed commits instead of hardcoding `0o644`
- Fix `ResolveHEAD` to return `("", nil)` for repos with no commits, matching its interface contract
- Wire `CommitReplayer` and `ReplayCommits()` into the CLI composition root

## Test plan

- [x] `TestResolveHEAD_NoCommits` — empty repo returns `("", nil)` not an error
- [x] `TestReplay_HeadDiverged` — diverged original returns `Diverged=true, Replayed=0`
- [x] `TestReplay_PreservesExecutableBit` — executable files keep `0o755` after replay
- [x] `TestGetFileModeAtCommit` — table-driven: regular=`0o644`, executable=`0o755`, missing=`0o644` fallback
- [x] All existing replay tests continue to pass
- [x] Manual E2E: `bbox claude-code -- -p "..."` successfully replayed 1 commit onto original repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)