### PR TITLE
Add --env-forward CLI flag

### DIFF
--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -93,6 +93,7 @@ func rootCmd() *cobra.Command {
 		noImageCache      bool
 		timings           bool
 		exec              string
+		envForward        []string
 	)
 
 	cmd := &cobra.Command{
@@ -118,6 +119,7 @@ Example:
   bbox claude-code --allow-host "custom-api.example.com:443"
   bbox claude-code --no-mcp
   bbox claude-code --mcp-group "coding-tools"
+  bbox claude-code --env-forward ANTHROPIC_API_KEY --env-forward 'OPENCODE_*'
   bbox claude-code -- --help
   bbox claude-code --exec /bin/bash`,
 		Args:    cobra.MinimumNArgs(1),
@@ -156,6 +158,7 @@ Example:
 				timings:           timings,
 				exec:              exec,
 				commandArgs:       commandArgs,
+				envForward:        envForward,
 			})
 		},
 		SilenceUsage:  true,
@@ -189,6 +192,7 @@ Example:
 	cmd.Flags().BoolVar(&noImageCache, "no-image-cache", false, "Disable OCI image caching (fresh pull every run)")
 	cmd.Flags().BoolVar(&timings, "timings", false, "Print per-phase timing summary after run")
 	cmd.Flags().StringVar(&exec, "exec", "", "Override the agent command (e.g. /bin/bash for debugging)")
+	cmd.Flags().StringSliceVar(&envForward, "env-forward", nil, "Forward host env var into VM (exact name or glob like 'PREFIX_*', repeatable)")
 
 	// Add subcommands.
 	cmd.AddCommand(listCmd())
@@ -343,6 +347,7 @@ type runFlags struct {
 	timings           bool
 	exec              string
 	commandArgs       []string
+	envForward        []string
 }
 
 func run(parentCtx context.Context, agentName string, flags runFlags) error {
@@ -806,6 +811,7 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		CommandOverride: commandOverride,
 		LogLevel:        logLevel,
 		CommandArgs:     flags.commandArgs,
+		EnvForwardExtra: flags.envForward,
 		Snapshot: sandbox.SnapshotOpts{
 			Enabled:         true,
 			SnapshotMatcher: snapshotMatcher,

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -94,6 +94,10 @@ type RunOpts struct {
 	// TmpSizeMiB overrides the /tmp tmpfs size in MiB (0 = use agent/global default).
 	TmpSizeMiB uint32
 
+	// EnvForwardExtra holds additional env var patterns from CLI flags.
+	// These are merged with the agent's configured patterns.
+	EnvForwardExtra []string
+
 	// Terminal provides I/O streams for the session. Required for Run().
 	Terminal session.Terminal
 }
@@ -347,6 +351,9 @@ func (s *SandboxRunner) Prepare(ctx context.Context, agentName string, opts RunO
 	}
 
 	allPatterns := ag.EnvForward
+	if len(opts.EnvForwardExtra) > 0 {
+		allPatterns = mergeEnvPatterns(allPatterns, opts.EnvForwardExtra)
+	}
 	if opts.GitTokenEnabled {
 		allPatterns = mergeEnvPatterns(allPatterns, domaingit.CommonEnvPatterns())
 	}

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -851,6 +851,84 @@ func TestSandboxRunner_Prepare_Success(t *testing.T) {
 	assert.True(t, cloner.createCalled)
 }
 
+func TestSandboxRunner_Prepare_EnvForwardExtra(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		agentEnvForward []string
+		envForwardExtra []string
+		envVars         []string
+		wantKeys        []string
+		desc            string
+	}{
+		{
+			name:            "extra patterns merge with agent patterns",
+			agentEnvForward: []string{"AGENT_KEY"},
+			envForwardExtra: []string{"CLI_KEY"},
+			envVars:         []string{"AGENT_KEY=a", "CLI_KEY=b"},
+			wantKeys:        []string{"AGENT_KEY", "CLI_KEY"},
+			desc:            "both agent and CLI-forwarded vars appear",
+		},
+		{
+			name:            "duplicate pattern is deduplicated",
+			agentEnvForward: []string{"SHARED"},
+			envForwardExtra: []string{"SHARED", "EXTRA"},
+			envVars:         []string{"SHARED=s", "EXTRA=e"},
+			wantKeys:        []string{"SHARED", "EXTRA"},
+			desc:            "overlapping pattern doesn't cause duplicate matching",
+		},
+		{
+			name:            "nil extra does not alter agent patterns",
+			agentEnvForward: []string{"ONLY_AGENT"},
+			envForwardExtra: nil,
+			envVars:         []string{"ONLY_AGENT=x"},
+			wantKeys:        []string{"ONLY_AGENT"},
+			desc:            "nil EnvForwardExtra is a no-op",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			testAgent := agent.Agent{
+				Name:          "test-agent",
+				Image:         "test-image:latest",
+				Command:       []string{"test-cmd"},
+				EnvForward:    tt.agentEnvForward,
+				DefaultCPUs:   2,
+				DefaultMemory: bytesize.ByteSize(2048),
+			}
+
+			mvm := &mockVM{sshPort: 2222, sshKeyPath: "/tmp/key"}
+			runner := NewSandboxRunner(SandboxDeps{
+				Registry: &mockRegistry{agents: map[string]agent.Agent{
+					"test-agent": testAgent,
+				}},
+				VMRunner:      &mockVMRunner{vm: mvm},
+				SessionRunner: &mockSessionRunner{},
+				Config:        &SandboxConfig{},
+				EnvProvider:   &mockEnvProvider{vars: tt.envVars},
+				Logger:        testLogger(),
+			})
+
+			sb, err := runner.Prepare(context.Background(), "test-agent", RunOpts{
+				Workspace:       t.TempDir(),
+				EgressProfile:   string(egress.ProfilePermissive),
+				SessionID:       "abcd1234",
+				EnvForwardExtra: tt.envForwardExtra,
+			})
+			require.NoError(t, err)
+			defer func() { _ = sb.Cleanup() }()
+
+			for _, key := range tt.wantKeys {
+				assert.Contains(t, sb.EnvVars, key, tt.desc)
+			}
+		})
+	}
+}
+
 func TestSandboxRunner_Prepare_AgentNotFound(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Adds a repeatable `--env-forward` CLI flag for ad-hoc host env var forwarding into VMs (exact names or globs like `PREFIX_*`)
- CLI patterns are **additive** — merged with agent/config patterns via existing `mergeEnvPatterns` helper, consistent with `--exclude` and `--allow-host`
- Adds integration test verifying `EnvForwardExtra` flows through `Prepare()` into VM env vars (merge, dedup, nil no-op)

Closes #77

## Test plan

- [x] `CGO_ENABLED=0 go build ./cmd/bbox/` compiles cleanly
- [x] `CGO_ENABLED=0 golangci-lint run ./...` — 0 issues
- [x] `go test ./pkg/sandbox/` — all 34 tests pass (including 3 new sub-cases)
- [ ] Manual smoke test: `bbox claude-code --env-forward MY_VAR --env-forward 'CUSTOM_*'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)