### PR TITLE
Add gcc, glibc-dev, and Go PATH to base guest image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -20,6 +20,8 @@ RUN apk add --no-cache \
     curl \
     openssh-client \
     make \
+    gcc \
+    glibc-dev \
     go \
     python3 \
     py3-pip \
@@ -27,6 +29,9 @@ RUN apk add --no-cache \
     nodejs \
     npm \
     rust
+
+# Put Go and user-local binaries on PATH for all shells
+ENV PATH="/usr/lib/go/bin:/home/sandbox/go/bin:/home/sandbox/.local/bin:${PATH}"
 
 # Ensure /usr/local/bin exists (not present in Wolfi by default)
 RUN mkdir -p /usr/local/bin


### PR DESCRIPTION
The Go toolchain was installed but not on PATH, causing agents to fail
to locate it. Add `/usr/lib/go/bin`, `~/go/bin`, and `~/.local/bin` to
the image-wide PATH via ENV. Also add `gcc` and `glibc-dev` so CGO-
enabled builds work out of the box.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
