### PR TITLE
Fix guest PATH clobbered by /etc/profile and Claude native warning

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -30,8 +30,14 @@ RUN apk add --no-cache \
     npm \
     rust
 
-# Put Go and user-local binaries on PATH for all shells
+# Put Go and user-local binaries on PATH for all shells.
+# NOTE: Docker ENV PATH is NOT enough — Wolfi's /etc/profile rebuilds PATH
+# from scratch, and the SSH session sources /etc/profile. We must use a
+# profile.d drop-in so the paths survive into the agent's shell.
 ENV PATH="/usr/lib/go/bin:/home/sandbox/go/bin:/home/sandbox/.local/bin:${PATH}"
+RUN printf '%s\n' \
+    'export PATH="/usr/lib/go/bin:/home/sandbox/go/bin:/home/sandbox/.local/bin:${PATH}"' \
+    > /etc/profile.d/broodbox-path.sh
 
 # Ensure /usr/local/bin exists (not present in Wolfi by default)
 RUN mkdir -p /usr/local/bin

--- a/images/claude-code/Dockerfile
+++ b/images/claude-code/Dockerfile
@@ -8,12 +8,17 @@ FROM ${BASE_IMAGE}
 
 # Install Claude Code native binary.
 # The installer creates a symlink at /root/.local/bin/claude pointing to the
-# versioned binary under /root/.local/share/claude/versions/. We must copy
-# the real binary (not the symlink) so it works for the non-root sandbox user.
+# versioned binary under /root/.local/share/claude/versions/. We copy the real
+# binary to /usr/local/bin so it works for the non-root sandbox user, and also
+# symlink it to /home/sandbox/.local/bin/claude — the path the native installer
+# records as installMethod "native". Without this symlink Claude Code emits:
+#   "installMethod is native, but claude command not found at
+#    /home/sandbox/.local/bin/claude"
 RUN export PATH="$HOME/.local/bin:$PATH" && \
     curl -fsSL https://claude.ai/install.sh | bash && \
     cp -L /root/.local/bin/claude /usr/local/bin/claude && \
-    rm -rf /root/.local/share/claude /root/.local/bin/claude
+    rm -rf /root/.local/share/claude /root/.local/bin/claude && \
+    ln -s /usr/local/bin/claude /home/sandbox/.local/bin/claude
 
 # Set sandbox env vars that should be baked into the image
 ENV IS_SANDBOX=1


### PR DESCRIPTION
Wolfi's /etc/profile rebuilds PATH from scratch, overwriting the
Dockerfile ENV PATH that added /usr/lib/go/bin, ~/go/bin, and
~/.local/bin. Since the SSH session sources /etc/profile before
running the agent command, Go and user-local binaries were invisible.

Add a /etc/profile.d/broodbox-path.sh drop-in so the custom paths
survive the profile reset.

Also symlink /usr/local/bin/claude → /home/sandbox/.local/bin/claude
in the claude-code image so Claude Code's native installMethod check
finds the binary at the expected path, silencing the startup warning.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
