### PR TITLE
Fix CGO gcc exec failure by adding bash-binsh to base image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -9,6 +9,7 @@ FROM cgr.dev/chainguard/wolfi-base:latest
 
 RUN apk add --no-cache \
     bash \
+    bash-binsh \
     git \
     ca-certificates-bundle \
     coreutils \


### PR DESCRIPTION
Wolfi's gcc package installs a shell wrapper (gcc-wrapper) at
/usr/local/bin/gcc with a #!/bin/sh shebang. The busybox trigger
that normally provides /usr/bin/sh doesn't always fire reliably
in Docker builds, leaving /bin/sh missing. This causes CGO to
fail with a misleading "fork/exec /usr/local/bin/gcc: no such
file or directory" — the kernel returns ENOENT for the missing
interpreter, not the gcc binary itself.

Add bash-binsh, the official Wolfi subpackage that provides
/usr/bin/sh -> /usr/bin/bash with proper APK dependency tracking
and provider-priority 60.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
