### PR TITLE
Pass dummy auth header to make MCP work again

### DIFF
--- a/internal/infra/vm/mcpconfig.go
+++ b/internal/infra/vm/mcpconfig.go
@@ -48,8 +48,9 @@ type claudeCodeConfig struct {
 
 // claudeCodeServer describes a single MCP server entry for Claude Code.
 type claudeCodeServer struct {
-	Type string `json:"type"`
-	URL  string `json:"url"`
+	Type    string            `json:"type"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 // injectClaudeCodeMCP merges an MCP server entry into ~/.claude.json,
@@ -63,6 +64,9 @@ func injectClaudeCodeMCP(rootfsPath, gatewayIP string, port uint16, chown ChownF
 		"sandbox-tools": {
 			Type: "http",
 			URL:  fmt.Sprintf("http://%s:%d/mcp", gatewayIP, port),
+			Headers: map[string]string{
+				"Authorization": "Bearer anonymous",
+			},
 		},
 	}
 

--- a/internal/infra/vm/mcpconfig_test.go
+++ b/internal/infra/vm/mcpconfig_test.go
@@ -216,7 +216,8 @@ func TestInjectClaudeCodeMCP_NoExtraFields(t *testing.T) {
 	assert.Len(t, servers, 1, "should have only sandbox-tools")
 
 	entry := servers["sandbox-tools"].(map[string]any)
-	assert.Len(t, entry, 2, "server entry should have only type and url")
+	assert.Len(t, entry, 3, "server entry should have type, url, and headers")
+	assert.Contains(t, entry, "headers")
 }
 
 func TestInjectCodexMCP(t *testing.T) {


### PR DESCRIPTION
Claude Code v2.1.83 now requires auth for non-localhost MCPs. This is
problematic for brood box since it listens on 192.168.127.1. So, this
passes a dummy auth header to make it work.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
