### PR TITLE
Add settings_import section to config init template

### DIFF
--- a/internal/infra/config/writer.go
+++ b/internal/infra/config/writer.go
@@ -116,6 +116,27 @@ var defaultConfigTemplate = `# Brood Box configuration
 #   # VM before the agent starts (default: false).
 #   seed_host_credentials: false
 
+# Agent settings injection into the VM.
+# Copies host agent settings (rules, skills, themes, etc.) into the guest.
+# Equivalent of --no-settings when set to enabled: false.
+# settings_import:
+#   # Enable or disable all settings injection (default: true).
+#   # Set to false to disable (same as --no-settings flag).
+#   enabled: true
+#
+#   # Control which categories of settings are imported.
+#   # Each category defaults to true when omitted or null.
+#   # categories:
+#   #   settings: true
+#   #   instructions: true
+#   #   rules: true
+#   #   agents: true
+#   #   skills: true
+#   #   commands: true
+#   #   tools: true
+#   #   plugins: true
+#   #   themes: true
+
 # Host runtime dependency configuration.
 # runtime:
 #   # Download libkrunfw firmware at runtime (default: true).
@@ -159,6 +180,14 @@ var defaultConfigTemplate = `# Brood Box configuration
 #   #     enabled: true
 #   #     authz:
 #   #       profile: "full-access"
+#   #
+#   #   # Override settings injection for this agent.
+#   #   # Can only tighten (disable), not enable if globally disabled.
+#   #   settings_import:
+#   #     enabled: true
+#   #     categories:
+#   #       rules: true
+#   #       skills: true
 `
 
 // WriteDefault writes the default config template to the given path.

--- a/internal/infra/config/writer_test.go
+++ b/internal/infra/config/writer_test.go
@@ -126,7 +126,8 @@ func TestWriteDefault(t *testing.T) {
 				for _, section := range []string{
 					"defaults:", "review:", "network:",
 					"mcp:", "authz:", "config:",
-					"git:", "auth:", "runtime:", "agents:",
+					"git:", "auth:", "settings_import:",
+					"runtime:", "agents:",
 				} {
 					assert.Contains(t, content, section,
 						"template should contain section %q", section)


### PR DESCRIPTION
## Summary
- `settings_import` (the config equivalent of `--no-settings`) was missing from the template generated by `bbox config init`
- Added top-level `settings_import:` section documenting `enabled` and per-category controls
- Added per-agent `settings_import:` override in the `agents:` section
- Updated template section coverage test to include `settings_import:`

## Test plan
- [x] `TestWriteDefault` passes, including the "template contains all config sections" case

🤖 Generated with [Claude Code](https://claude.com/claude-code)