### PR TITLE
Extract settings from guest rootfs after VM shutdown

### DIFF
--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -626,9 +626,10 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 	}
 
 	// Wire settings injector (enabled by default, --no-settings to disable).
+	var settingsInjector *infrasettings.FSInjector
 	settingsEnabled := cfg.SettingsImport.IsEnabled() && !flags.noSettings
 	if settingsEnabled {
-		settingsInjector := infrasettings.NewFSInjector(logger)
+		settingsInjector = infrasettings.NewFSInjector(logger)
 		vmRunnerOpts = append(vmRunnerOpts, infravm.WithSettingsInjector(settingsInjector))
 	} else if flags.noSettings {
 		// Ensure sandbox config reflects disabled state for the application layer.
@@ -638,14 +639,15 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 
 	// Wire dependencies.
 	deps := sandbox.SandboxDeps{
-		Registry:        registry,
-		VMRunner:        infravm.NewMicroVMRunner(logger, vmRunnerOpts...),
-		SessionRunner:   infrassh.NewInteractiveSession(logger),
-		Config:          sandboxCfg,
-		EnvProvider:     agent.NewOSEnvProvider(os.Environ),
-		Logger:          logger,
-		Observer:        observer,
-		CredentialStore: credentialStore,
+		Registry:         registry,
+		VMRunner:         infravm.NewMicroVMRunner(logger, vmRunnerOpts...),
+		SessionRunner:    infrassh.NewInteractiveSession(logger),
+		Config:           sandboxCfg,
+		EnvProvider:      agent.NewOSEnvProvider(os.Environ),
+		Logger:           logger,
+		Observer:         observer,
+		CredentialStore:  credentialStore,
+		SettingsInjector: settingsInjector,
 	}
 
 	// Validate MCP authz profile flag early (before wiring).

--- a/internal/infra/settings/injector.go
+++ b/internal/infra/settings/injector.go
@@ -72,6 +72,184 @@ func (f *FSInjector) Inject(rootfsPath, hostHomeDir string, manifest settings.Ma
 	return result, nil
 }
 
+// Extract copies settings files from the guest rootfs back to the host
+// home directory. For KindFile and KindDirectory entries the guest file is
+// copied directly. For KindMergeFile entries the guest file is only written
+// when the host file does not already exist — this prevents overwriting
+// filtered fields that were stripped during injection.
+func (f *FSInjector) Extract(rootfsPath, hostHomeDir string, manifest settings.Manifest) (settings.InjectionResult, error) {
+	c := &counters{}
+
+	for _, entry := range manifest.Entries {
+		if err := f.extractEntry(rootfsPath, hostHomeDir, entry, c); err != nil {
+			return settings.InjectionResult{}, fmt.Errorf("extracting %q: %w", entry.GuestPath, err)
+		}
+	}
+
+	result := settings.InjectionResult{
+		FileCount:  c.fileCount,
+		TotalBytes: c.totalSize,
+	}
+
+	f.logger.Info("settings extraction complete",
+		"files", result.FileCount, "total_bytes", result.TotalBytes)
+	return result, nil
+}
+
+func (f *FSInjector) extractEntry(
+	rootfsPath, hostHomeDir string,
+	entry settings.Entry,
+	c *counters,
+) error {
+	guestPath := filepath.Join(rootfsPath, sandboxHome, entry.GuestPath)
+
+	info, err := os.Lstat(guestPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			f.logger.Debug("guest file not found, skipping extraction", "path", entry.GuestPath)
+			return nil
+		}
+		return fmt.Errorf("stat guest file: %w", err)
+	}
+
+	// Skip symlinks.
+	if info.Mode()&os.ModeSymlink != 0 {
+		f.logger.Warn("skipping symlink during extraction", "path", entry.GuestPath)
+		return nil
+	}
+
+	// For merge files, only extract if the host file does NOT exist.
+	// This prevents overwriting fields that were filtered during injection.
+	if entry.Kind == settings.KindMergeFile {
+		hostPath := filepath.Join(hostHomeDir, entry.HostPath)
+		if _, statErr := os.Lstat(hostPath); statErr == nil {
+			f.logger.Debug("host merge file exists, skipping extraction to avoid overwriting filtered fields",
+				"path", entry.HostPath)
+			return nil
+		}
+	}
+
+	if info.IsDir() {
+		return f.extractDirectory(rootfsPath, hostHomeDir, entry, c, 0)
+	}
+	return f.extractFile(rootfsPath, hostHomeDir, entry, c)
+}
+
+func (f *FSInjector) extractFile(
+	rootfsPath, hostHomeDir string,
+	entry settings.Entry,
+	c *counters,
+) error {
+	guestPath := filepath.Join(rootfsPath, sandboxHome, entry.GuestPath)
+
+	if err := validateContainment(filepath.Join(rootfsPath, sandboxHome), guestPath); err != nil {
+		return fmt.Errorf("guest path containment: %w", err)
+	}
+
+	data, err := readFileNoFollow(guestPath)
+	if err != nil {
+		return fmt.Errorf("reading guest file: %w", err)
+	}
+
+	dataSize := int64(len(data))
+	if dataSize > settings.MaxFileSize {
+		return fmt.Errorf("file %q exceeds max size (%d > %d)", entry.GuestPath, dataSize, settings.MaxFileSize)
+	}
+	if c.fileCount >= settings.MaxFileCount {
+		return fmt.Errorf("file count would exceed limit (%d)", settings.MaxFileCount)
+	}
+	if c.totalSize+dataSize > settings.MaxTotalSize {
+		return fmt.Errorf("aggregate size would exceed limit (%d)", settings.MaxTotalSize)
+	}
+
+	dstPath := filepath.Join(hostHomeDir, entry.HostPath)
+
+	if err := validateContainment(hostHomeDir, dstPath); err != nil {
+		return fmt.Errorf("host path containment: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dstPath), dirPerm); err != nil {
+		return fmt.Errorf("creating parent dirs: %w", err)
+	}
+
+	if err := os.WriteFile(dstPath, data, filePerm); err != nil {
+		return fmt.Errorf("writing host file: %w", err)
+	}
+
+	c.fileCount++
+	c.totalSize += dataSize
+
+	f.logger.Debug("extracted file", "src", entry.GuestPath, "dst", entry.HostPath)
+	return nil
+}
+
+func (f *FSInjector) extractDirectory(
+	rootfsPath, hostHomeDir string,
+	entry settings.Entry,
+	c *counters,
+	depth int,
+) error {
+	if depth >= settings.MaxDepth {
+		f.logger.Warn("skipping directory exceeding max depth during extraction", "path", entry.GuestPath, "depth", depth)
+		return nil
+	}
+
+	guestPath := filepath.Join(rootfsPath, sandboxHome, entry.GuestPath)
+
+	if err := validateContainment(filepath.Join(rootfsPath, sandboxHome), guestPath); err != nil {
+		return fmt.Errorf("guest path containment: %w", err)
+	}
+
+	entries, err := os.ReadDir(guestPath)
+	if err != nil {
+		return fmt.Errorf("reading guest directory: %w", err)
+	}
+
+	dstPath := filepath.Join(hostHomeDir, entry.HostPath)
+
+	if err := validateContainment(hostHomeDir, dstPath); err != nil {
+		return fmt.Errorf("host path containment: %w", err)
+	}
+
+	if err := os.MkdirAll(dstPath, dirPerm); err != nil {
+		return fmt.Errorf("creating host directory: %w", err)
+	}
+
+	for _, de := range entries {
+		childGuestPath := filepath.Join(entry.GuestPath, de.Name())
+		childHostPath := filepath.Join(entry.HostPath, de.Name())
+
+		childInfo, err := os.Lstat(filepath.Join(rootfsPath, sandboxHome, childGuestPath))
+		if err != nil {
+			return fmt.Errorf("lstat %q: %w", childGuestPath, err)
+		}
+
+		if childInfo.Mode()&os.ModeSymlink != 0 {
+			f.logger.Warn("skipping symlink during extraction", "path", childGuestPath)
+			continue
+		}
+
+		childEntry := settings.Entry{
+			HostPath:  childHostPath,
+			GuestPath: childGuestPath,
+		}
+
+		if childInfo.IsDir() {
+			childEntry.Kind = settings.KindDirectory
+			if err := f.extractDirectory(rootfsPath, hostHomeDir, childEntry, c, depth+1); err != nil {
+				return err
+			}
+		} else {
+			childEntry.Kind = settings.KindFile
+			if err := f.extractFile(rootfsPath, hostHomeDir, childEntry, c); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
 func (f *FSInjector) processEntry(
 	rootfsPath, hostHomeDir string,
 	entry settings.Entry,

--- a/internal/infra/settings/injector.go
+++ b/internal/infra/settings/injector.go
@@ -53,18 +53,23 @@ type counters struct {
 
 // Inject processes each entry in the manifest, copying files from hostHomeDir
 // into rootfsPath according to each entry's Kind.
-func (f *FSInjector) Inject(rootfsPath, hostHomeDir string, manifest settings.Manifest) error {
+func (f *FSInjector) Inject(rootfsPath, hostHomeDir string, manifest settings.Manifest) (settings.InjectionResult, error) {
 	c := &counters{}
 
 	for _, entry := range manifest.Entries {
 		if err := f.processEntry(rootfsPath, hostHomeDir, entry, c); err != nil {
-			return fmt.Errorf("injecting %q: %w", entry.HostPath, err)
+			return settings.InjectionResult{}, fmt.Errorf("injecting %q: %w", entry.HostPath, err)
 		}
 	}
 
+	result := settings.InjectionResult{
+		FileCount:  c.fileCount,
+		TotalBytes: c.totalSize,
+	}
+
 	f.logger.Info("settings injection complete",
-		"files", c.fileCount, "total_bytes", c.totalSize)
-	return nil
+		"files", result.FileCount, "total_bytes", result.TotalBytes)
+	return result, nil
 }
 
 func (f *FSInjector) processEntry(

--- a/internal/infra/settings/injector_test.go
+++ b/internal/infra/settings/injector_test.go
@@ -145,7 +145,7 @@ func TestFSInjector_File(t *testing.T) {
 
 			inj := NewFSInjector(testLogger())
 			manifest := settings.Manifest{Entries: []settings.Entry{tt.entry}}
-			err := inj.Inject(rootfs, hostHome, manifest)
+			_, err := inj.Inject(rootfs, hostHome, manifest)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -313,7 +313,7 @@ func TestFSInjector_Directory(t *testing.T) {
 
 			inj := NewFSInjector(testLogger())
 			manifest := settings.Manifest{Entries: []settings.Entry{tt.entry}}
-			err := inj.Inject(rootfs, hostHome, manifest)
+			_, err := inj.Inject(rootfs, hostHome, manifest)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -417,7 +417,7 @@ func TestFSInjector_MergeFileJSON(t *testing.T) {
 
 			inj := NewFSInjector(testLogger())
 			manifest := settings.Manifest{Entries: []settings.Entry{tt.entry}}
-			err := inj.Inject(rootfs, hostHome, manifest)
+			_, err := inj.Inject(rootfs, hostHome, manifest)
 			require.NoError(t, err)
 
 			dstPath := filepath.Join(rootfs, sandboxHome, tt.entry.GuestPath)
@@ -513,7 +513,7 @@ func TestFSInjector_MergeFileTOML(t *testing.T) {
 
 			inj := NewFSInjector(testLogger())
 			manifest := settings.Manifest{Entries: []settings.Entry{tt.entry}}
-			err := inj.Inject(rootfs, hostHome, manifest)
+			_, err := inj.Inject(rootfs, hostHome, manifest)
 			require.NoError(t, err)
 
 			dstPath := filepath.Join(rootfs, sandboxHome, tt.entry.GuestPath)
@@ -625,7 +625,7 @@ func TestFSInjector_MergeFileJSONC(t *testing.T) {
 
 	inj := NewFSInjector(testLogger())
 	manifest := settings.Manifest{Entries: []settings.Entry{entry}}
-	err := inj.Inject(rootfs, hostHome, manifest)
+	_, err := inj.Inject(rootfs, hostHome, manifest)
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(rootfs, sandboxHome, "settings.json"))

--- a/internal/infra/settings/injector_test.go
+++ b/internal/infra/settings/injector_test.go
@@ -1164,3 +1164,158 @@ func TestApplyDenySubKeys_EndToEnd(t *testing.T) {
 	_, hasKey = gl["apiKey"]
 	assert.False(t, hasKey, "gitlab apiKey should be stripped")
 }
+
+func TestFSInjector_Extract_File(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hostHome := t.TempDir()
+	setupRootfs(t, rootfs)
+
+	// Place a file in the guest rootfs (as if agent created it).
+	guestFile := filepath.Join(rootfs, sandboxHome, ".claude", "settings.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(guestFile), 0755))
+	require.NoError(t, os.WriteFile(guestFile, []byte(`{"theme":"dark"}`), 0644))
+
+	entry := settings.Entry{
+		Category:  "settings",
+		HostPath:  ".claude/settings.json",
+		GuestPath: ".claude/settings.json",
+		Kind:      settings.KindFile,
+	}
+
+	inj := NewFSInjector(testLogger())
+	manifest := settings.Manifest{Entries: []settings.Entry{entry}}
+	result, err := inj.Extract(rootfs, hostHome, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FileCount)
+
+	// Verify file was written to host.
+	data, err := os.ReadFile(filepath.Join(hostHome, ".claude", "settings.json"))
+	require.NoError(t, err)
+	assert.Equal(t, `{"theme":"dark"}`, string(data))
+}
+
+func TestFSInjector_Extract_SkipsMissingGuest(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hostHome := t.TempDir()
+	setupRootfs(t, rootfs)
+
+	entry := settings.Entry{
+		Category:  "settings",
+		HostPath:  ".claude/settings.json",
+		GuestPath: ".claude/settings.json",
+		Kind:      settings.KindFile,
+	}
+
+	inj := NewFSInjector(testLogger())
+	manifest := settings.Manifest{Entries: []settings.Entry{entry}}
+	result, err := inj.Extract(rootfs, hostHome, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.FileCount)
+}
+
+func TestFSInjector_Extract_MergeFileSkipsWhenHostExists(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hostHome := t.TempDir()
+	setupRootfs(t, rootfs)
+
+	// Place file in both guest and host.
+	guestFile := filepath.Join(rootfs, sandboxHome, ".claude", "settings.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(guestFile), 0755))
+	require.NoError(t, os.WriteFile(guestFile, []byte(`{"modified":true}`), 0644))
+
+	hostFile := filepath.Join(hostHome, ".claude", "settings.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(hostFile), 0755))
+	require.NoError(t, os.WriteFile(hostFile, []byte(`{"original":true}`), 0644))
+
+	entry := settings.Entry{
+		Category:  "settings",
+		HostPath:  ".claude/settings.json",
+		GuestPath: ".claude/settings.json",
+		Kind:      settings.KindMergeFile,
+		Format:    "json",
+	}
+
+	inj := NewFSInjector(testLogger())
+	manifest := settings.Manifest{Entries: []settings.Entry{entry}}
+	result, err := inj.Extract(rootfs, hostHome, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.FileCount)
+
+	// Host file should be unchanged.
+	data, err := os.ReadFile(hostFile)
+	require.NoError(t, err)
+	assert.Equal(t, `{"original":true}`, string(data))
+}
+
+func TestFSInjector_Extract_MergeFileExtractsWhenHostMissing(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hostHome := t.TempDir()
+	setupRootfs(t, rootfs)
+
+	// Place file only in guest.
+	guestFile := filepath.Join(rootfs, sandboxHome, ".claude", "settings.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(guestFile), 0755))
+	require.NoError(t, os.WriteFile(guestFile, []byte(`{"new":true}`), 0644))
+
+	entry := settings.Entry{
+		Category:  "settings",
+		HostPath:  ".claude/settings.json",
+		GuestPath: ".claude/settings.json",
+		Kind:      settings.KindMergeFile,
+		Format:    "json",
+	}
+
+	inj := NewFSInjector(testLogger())
+	manifest := settings.Manifest{Entries: []settings.Entry{entry}}
+	result, err := inj.Extract(rootfs, hostHome, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FileCount)
+
+	data, err := os.ReadFile(filepath.Join(hostHome, ".claude", "settings.json"))
+	require.NoError(t, err)
+	assert.Equal(t, `{"new":true}`, string(data))
+}
+
+func TestFSInjector_Extract_Directory(t *testing.T) {
+	t.Parallel()
+
+	rootfs := t.TempDir()
+	hostHome := t.TempDir()
+	setupRootfs(t, rootfs)
+
+	// Create a directory with files in the guest.
+	rulesDir := filepath.Join(rootfs, sandboxHome, ".claude", "rules")
+	require.NoError(t, os.MkdirAll(rulesDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(rulesDir, "rule1.md"), []byte("rule 1"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(rulesDir, "rule2.md"), []byte("rule 2"), 0644))
+
+	entry := settings.Entry{
+		Category:  "rules",
+		HostPath:  ".claude/rules",
+		GuestPath: ".claude/rules",
+		Kind:      settings.KindDirectory,
+		Optional:  true,
+	}
+
+	inj := NewFSInjector(testLogger())
+	manifest := settings.Manifest{Entries: []settings.Entry{entry}}
+	result, err := inj.Extract(rootfs, hostHome, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.FileCount)
+
+	data1, err := os.ReadFile(filepath.Join(hostHome, ".claude", "rules", "rule1.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "rule 1", string(data1))
+
+	data2, err := os.ReadFile(filepath.Join(hostHome, ".claude", "rules", "rule2.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "rule 2", string(data2))
+}

--- a/internal/infra/vm/settingshook.go
+++ b/internal/infra/vm/settingshook.go
@@ -30,6 +30,15 @@ func InjectSettings(injector settings.Injector, manifest *settings.Manifest) fun
 			"entries", len(manifest.Entries),
 		)
 
-		return injector.Inject(rootfsPath, hostHome, *manifest)
+		result, err := injector.Inject(rootfsPath, hostHome, *manifest)
+		if err != nil {
+			return err
+		}
+
+		if result.FileCount == 0 {
+			slog.Info("no host settings files found to inject")
+		}
+
+		return nil
 	}
 }

--- a/internal/infra/vm/settingshook_test.go
+++ b/internal/infra/vm/settingshook_test.go
@@ -23,13 +23,13 @@ type mockInjectCall struct {
 	Manifest    settings.Manifest
 }
 
-func (m *mockInjector) Inject(rootfsPath, hostHomeDir string, manifest settings.Manifest) error {
+func (m *mockInjector) Inject(rootfsPath, hostHomeDir string, manifest settings.Manifest) (settings.InjectionResult, error) {
 	m.calls = append(m.calls, mockInjectCall{
 		RootfsPath:  rootfsPath,
 		HostHomeDir: hostHomeDir,
 		Manifest:    manifest,
 	})
-	return nil
+	return settings.InjectionResult{FileCount: len(manifest.Entries)}, nil
 }
 
 func TestInjectSettings_NilManifest(t *testing.T) {

--- a/internal/infra/vm/settingshook_test.go
+++ b/internal/infra/vm/settingshook_test.go
@@ -32,6 +32,10 @@ func (m *mockInjector) Inject(rootfsPath, hostHomeDir string, manifest settings.
 	return settings.InjectionResult{FileCount: len(manifest.Entries)}, nil
 }
 
+func (m *mockInjector) Extract(_, _ string, _ settings.Manifest) (settings.InjectionResult, error) {
+	return settings.InjectionResult{}, nil
+}
+
 func TestInjectSettings_NilManifest(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/domain/progress/observer.go
+++ b/pkg/domain/progress/observer.go
@@ -27,6 +27,8 @@ const (
 	PhaseConfiguringMCP
 	// PhaseSavingCredentials is the credential persistence phase.
 	PhaseSavingCredentials
+	// PhaseSavingSettings is the settings persistence phase.
+	PhaseSavingSettings
 	// PhaseCleaning is the snapshot cleanup phase.
 	PhaseCleaning
 )

--- a/pkg/domain/settings/settings.go
+++ b/pkg/domain/settings/settings.go
@@ -82,9 +82,18 @@ const (
 	MaxDepth = 8
 )
 
+// InjectionResult summarises what was actually injected.
+type InjectionResult struct {
+	// FileCount is the number of files written into the guest rootfs.
+	FileCount int
+
+	// TotalBytes is the aggregate size of all written files.
+	TotalBytes int64
+}
+
 // Injector copies filtered settings from the host into the guest rootfs.
 type Injector interface {
 	// Inject processes each entry in the manifest, copying files from
 	// hostHomeDir into rootfsPath according to each entry's Kind.
-	Inject(rootfsPath, hostHomeDir string, manifest Manifest) error
+	Inject(rootfsPath, hostHomeDir string, manifest Manifest) (InjectionResult, error)
 }

--- a/pkg/domain/settings/settings.go
+++ b/pkg/domain/settings/settings.go
@@ -91,9 +91,15 @@ type InjectionResult struct {
 	TotalBytes int64
 }
 
-// Injector copies filtered settings from the host into the guest rootfs.
+// Injector copies filtered settings between the host and guest rootfs.
 type Injector interface {
 	// Inject processes each entry in the manifest, copying files from
 	// hostHomeDir into rootfsPath according to each entry's Kind.
 	Inject(rootfsPath, hostHomeDir string, manifest Manifest) (InjectionResult, error)
+
+	// Extract copies settings files from the guest rootfs back to the
+	// host home directory. Only files present in the guest are written;
+	// KindMergeFile entries are only extracted when the host file does
+	// not already exist (to avoid overwriting filtered fields).
+	Extract(rootfsPath, hostHomeDir string, manifest Manifest) (InjectionResult, error)
 }

--- a/pkg/runtime/factory.go
+++ b/pkg/runtime/factory.go
@@ -135,6 +135,7 @@ func NewDefaultSandboxDeps(opts DefaultSandboxDepsOpts) sandbox.SandboxDeps {
 		),
 		Differ:                 infradiff.NewFSDiffer(),
 		Flusher:                infrareview.NewFSFlusher(),
+		SettingsInjector:       settingsInjector,
 		MCPProvider:            opts.MCPProvider,
 		SnapshotPostProcessors: opts.SnapshotPostProcessors,
 		GitIdentityProvider:    gitIdentityProvider,

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -143,6 +144,9 @@ type SandboxDeps struct {
 	// CredentialStore persists agent credentials between sessions (nil = disabled).
 	CredentialStore credential.Store
 
+	// SettingsInjector handles host-to-guest settings injection and extraction (nil = disabled).
+	SettingsInjector settings.Injector
+
 	// MCPProvider creates host services for MCP proxy (nil = disabled).
 	MCPProvider hostservice.Provider
 
@@ -156,16 +160,17 @@ type SandboxDeps struct {
 // Sandbox holds the state of a running sandbox session.
 // Created by Prepare, consumed by Attach/Stop/Changes/Flush/Cleanup.
 type Sandbox struct {
-	Agent           agent.Agent
-	VM              domvm.VM
-	VMConfig        domvm.VMConfig
-	Snapshot        *workspace.Snapshot
-	WorkspacePath   string
-	DiffMatcher     snapshot.Matcher
-	EnvVars         map[string]string
-	ResolvedCommand []string
-	SSHAgentForward bool
-	SSHAuthSock     string
+	Agent              agent.Agent
+	VM                 domvm.VM
+	VMConfig           domvm.VMConfig
+	Snapshot           *workspace.Snapshot
+	WorkspacePath      string
+	DiffMatcher        snapshot.Matcher
+	EnvVars            map[string]string
+	ResolvedCommand    []string
+	SSHAgentForward    bool
+	SSHAuthSock        string
+	SettingsManifest   *settings.Manifest
 }
 
 // Cleanup releases resources (snapshot dir). Safe to call multiple times.
@@ -198,6 +203,7 @@ type SandboxRunner struct {
 	flusher                snapshot.Flusher
 	differ                 snapshot.Differ
 	credentialStore        credential.Store
+	settingsInjector       settings.Injector
 	mcpProvider            hostservice.Provider
 	snapshotPostProcessors []workspace.SnapshotPostProcessor
 	gitIdentityProvider    domaingit.IdentityProvider
@@ -222,6 +228,7 @@ func NewSandboxRunner(deps SandboxDeps) *SandboxRunner {
 		flusher:                deps.Flusher,
 		differ:                 deps.Differ,
 		credentialStore:        deps.CredentialStore,
+		settingsInjector:       deps.SettingsInjector,
 		mcpProvider:            deps.MCPProvider,
 		snapshotPostProcessors: deps.SnapshotPostProcessors,
 		gitIdentityProvider:    deps.GitIdentityProvider,
@@ -502,16 +509,17 @@ func (s *SandboxRunner) Prepare(ctx context.Context, agentName string, opts RunO
 	s.observer.Complete("Sandbox ready")
 
 	return &Sandbox{
-		Agent:           ag,
-		VM:              sandboxVM,
-		VMConfig:        vmCfg,
-		Snapshot:        snap,
-		WorkspacePath:   workspacePath,
-		DiffMatcher:     diffMatcher,
-		EnvVars:         envVars,
-		ResolvedCommand: command,
-		SSHAgentForward: opts.SSHAgentForward,
-		SSHAuthSock:     opts.SSHAuthSock,
+		Agent:            ag,
+		VM:               sandboxVM,
+		VMConfig:         vmCfg,
+		Snapshot:         snap,
+		WorkspacePath:    workspacePath,
+		DiffMatcher:      diffMatcher,
+		EnvVars:          envVars,
+		ResolvedCommand:  command,
+		SSHAgentForward:  opts.SSHAgentForward,
+		SSHAuthSock:      opts.SSHAuthSock,
+		SettingsManifest: settingsManifest,
 	}, nil
 }
 
@@ -558,6 +566,37 @@ func (s *SandboxRunner) ExtractCredentials(sb *Sandbox) {
 		return
 	}
 	s.observer.Complete(fmt.Sprintf("Saved credentials for %s", sb.Agent.Name))
+}
+
+// ExtractSettings saves agent settings from the guest rootfs back to the host.
+// Errors are logged as warnings, not fatal — settings save failure should
+// not prevent the user from working.
+func (s *SandboxRunner) ExtractSettings(sb *Sandbox) {
+	if s.settingsInjector == nil || sb.SettingsManifest == nil || len(sb.SettingsManifest.Entries) == 0 {
+		return
+	}
+	s.observer.Start(progress.PhaseSavingSettings, "Saving settings...")
+	rootfsPath := sb.VM.RootFSPath()
+
+	hostHome, err := os.UserHomeDir()
+	if err != nil {
+		s.observer.Warn("Could not resolve home directory for settings extraction")
+		s.logger.Warn("failed to resolve host home for settings extraction", "error", err)
+		return
+	}
+
+	result, err := s.settingsInjector.Extract(rootfsPath, hostHome, *sb.SettingsManifest)
+	if err != nil {
+		s.observer.Warn(fmt.Sprintf("Could not save settings for %s — see logs with --debug", sb.Agent.Name))
+		s.logger.Warn("failed to extract settings", "agent", sb.Agent.Name, "error", err)
+		return
+	}
+
+	if result.FileCount > 0 {
+		s.observer.Complete(fmt.Sprintf("Saved %d settings file(s) for %s", result.FileCount, sb.Agent.Name))
+	} else {
+		s.observer.Complete("No settings to save")
+	}
 }
 
 // Stop gracefully shuts down the sandbox VM.
@@ -629,6 +668,7 @@ func (s *SandboxRunner) Run(ctx context.Context, agentName string, opts RunOpts)
 	termErr := s.Attach(ctx, sb, opts.Terminal)
 
 	s.ExtractCredentials(sb)
+	s.ExtractSettings(sb)
 
 	if stopErr := s.Stop(sb); stopErr != nil {
 		s.logger.Error("failed to stop VM", "error", stopErr)


### PR DESCRIPTION
## Summary
- Add `Extract` method to the settings `Injector` interface, symmetric with `Inject`
- After the terminal session ends, settings files declared in the agent manifest are copied from the guest rootfs back to the host home directory
- `KindFile`/`KindDirectory` entries are extracted unconditionally
- `KindMergeFile` entries are only extracted when the host file does not already exist (avoids overwriting filtered fields)
- Wire `ExtractSettings` into the sandbox `Run()` lifecycle alongside `ExtractCredentials`
- Change `Inject` to return `InjectionResult{FileCount, TotalBytes}` for diagnostics
- Log explicitly when no host settings files were found during injection

Closes #100

## Files changed
- `pkg/domain/settings/settings.go` — `InjectionResult` type, `Extract` on `Injector` interface
- `pkg/domain/progress/observer.go` — `PhaseSavingSettings` phase
- `internal/infra/settings/injector.go` — `FSInjector.Inject` returns result, `FSInjector.Extract` implementation
- `internal/infra/vm/settingshook.go` — Log on empty injection
- `pkg/sandbox/sandbox.go` — `ExtractSettings`, `SettingsManifest` on `Sandbox`, `SettingsInjector` on deps
- `pkg/runtime/factory.go` — Wire `SettingsInjector` into default deps
- `cmd/bbox/main.go` — Pass injector to both VM runner and sandbox deps

## Test plan
- [x] `TestFSInjector_Extract_File` — extracts file from guest to host
- [x] `TestFSInjector_Extract_SkipsMissingGuest` — no-op when guest file doesn't exist
- [x] `TestFSInjector_Extract_MergeFileSkipsWhenHostExists` — preserves existing host merge file
- [x] `TestFSInjector_Extract_MergeFileExtractsWhenHostMissing` — extracts merge file when host has none
- [x] `TestFSInjector_Extract_Directory` — recursively extracts directory
- [x] All existing injection and hook tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)