### PR TITLE
Set OverrideUID on virtiofs mounts for macOS ownership

### DIFF
--- a/internal/infra/vm/runner.go
+++ b/internal/infra/vm/runner.go
@@ -306,8 +306,10 @@ func (r *MicroVMRunner) Start(ctx context.Context, cfg domvm.VMConfig) (domvm.VM
 			return nil, fmt.Errorf("resolving workspace path: %w", err)
 		}
 		opts = append(opts, microvm.WithVirtioFS(microvm.VirtioFSMount{
-			Tag:      "workspace",
-			HostPath: absPath,
+			Tag:         "workspace",
+			HostPath:    absPath,
+			OverrideUID: sandboxUID,
+			OverrideGID: sandboxGID,
 		}))
 	}
 


### PR DESCRIPTION
## Summary

- Set `OverrideUID`/`OverrideGID` on workspace and extra virtiofs mounts so libkrun reports correct ownership to the guest on macOS
- Fixes nested file writes failing inside the VM when the host UID differs from the sandbox UID

**Blocked on:** stacklok/go-microvm#64 being merged and tagged. The `OverrideUID` field does not exist in go-microvm v0.0.30.

## Test plan

- [ ] After go-microvm release, update `go.mod` to new version
- [ ] `task test` passes
- [ ] Manual: run `bbox claude-code` on macOS, verify writes to nested files work without pre-set xattrs

🤖 Generated with [Claude Code](https://claude.com/claude-code)