### PR TITLE
Surface config parse errors to stderr

### DIFF
--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -458,6 +458,7 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 
 	cfg, err := cfgLoader.Load()
 	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to load config %s: %s (using defaults)\n", cfgLoader.Path(), err)
 		logger.Warn("failed to load config, using defaults", "error", err)
 	}
 	if cfg == nil {
@@ -465,8 +466,10 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 	}
 
 	// Load per-workspace config and merge.
-	localCfg, err := infraconfig.LoadFromPath(filepath.Join(ws, domainconfig.LocalConfigFile))
+	localCfgPath := filepath.Join(ws, domainconfig.LocalConfigFile)
+	localCfg, err := infraconfig.LoadFromPath(localCfgPath)
 	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to load local config %s: %s (ignoring)\n", localCfgPath, err)
 		logger.Warn("failed to load local config, ignoring", "error", err)
 	}
 	warnLocalConfigOverrides(os.Stderr, localCfg, cfg)


### PR DESCRIPTION
## Summary

- Config parse errors for both global (`~/.config/broodbox/config.yaml`) and per-workspace (`.broodbox.yaml`) files were only logged to the slog file logger, which users never see unless they manually inspect `broodbox.log`
- This caused silent fallback to empty defaults when the config file had YAML syntax errors (e.g. a missing `#` on a comment line), making it appear as if settings like `cpus` and `memory` were being ignored
- Now prints a warning to stderr with the file path and error message so users get immediate feedback

## Test plan

- [ ] Introduce a YAML syntax error in `~/.config/broodbox/config.yaml` and run `bbox claude-code` — verify warning is printed to stderr
- [ ] Introduce a YAML syntax error in a workspace `.broodbox.yaml` and run `bbox claude-code` — verify warning is printed to stderr
- [ ] Run with a valid config — verify no spurious warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)