### PR TITLE
Reject bare wildcard env-forward patterns at load time

### DIFF
--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -379,6 +379,13 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 			flags.pull, domainconfig.ValidPullPolicies())
 	}
 
+	// Validate --env-forward flag. Bare "*" / empty / leading-star would
+	// either forward every host env var (exfiltration footgun) or silently
+	// match nothing (useless typo); reject here with a clear error.
+	if err := agent.ValidateEnvForwardPatterns(flags.envForward); err != nil {
+		return fmt.Errorf("invalid --env-forward: %w", err)
+	}
+
 	// --no-image-cache + --pull=never is a contradiction: "never" requires the
 	// cache to serve hits, but "no-image-cache" disables it entirely.
 	if flags.noImageCache && flags.pull == domainconfig.PullNever {
@@ -476,14 +483,21 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 
 	cfg, err := cfgLoader.Load()
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Warning: failed to load config %s: %s (using defaults)\n", cfgLoader.Path(), err)
-		logger.Warn("failed to load config, using defaults", "error", err)
+		// Fail fast on global config errors. Silently discarding every
+		// override because one line fails validation (or the file is
+		// unreadable) is worse UX than a hard error naming the file and
+		// the exact problem — the user owns this file and wants to know.
+		return fmt.Errorf("loading global config %s: %w", cfgLoader.Path(), err)
 	}
 	if cfg == nil {
 		cfg = &domainconfig.Config{}
 	}
 
-	// Load per-workspace config and merge.
+	// Load per-workspace config and merge. Unlike the global config, a
+	// bad workspace config is warn-and-skip: a malicious or corrupted
+	// `.broodbox.yaml` shipped by an untrusted repo must not be able to
+	// DOS the user's session — the operator can always run from a
+	// different directory or delete the file.
 	localCfgPath := filepath.Join(ws, domainconfig.LocalConfigFile)
 	localCfg, err := infraconfig.LoadFromPath(localCfgPath)
 	if err != nil {

--- a/internal/infra/config/loader.go
+++ b/internal/infra/config/loader.go
@@ -47,6 +47,10 @@ func (l *Loader) Load() (*domainconfig.Config, error) {
 		return nil, fmt.Errorf("parsing config file %s: %w", l.path, err)
 	}
 
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validating config file %s: %w", l.path, err)
+	}
+
 	return &cfg, nil
 }
 
@@ -70,6 +74,10 @@ func LoadFromPath(path string) (*domainconfig.Config, error) {
 	var cfg domainconfig.Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validating config file %s: %w", path, err)
 	}
 
 	return &cfg, nil

--- a/internal/infra/config/loader_test.go
+++ b/internal/infra/config/loader_test.go
@@ -145,3 +145,58 @@ func TestLoader_DefaultPath(t *testing.T) {
 	assert.Contains(t, loader.Path(), "broodbox")
 	assert.Contains(t, loader.Path(), "config.yaml")
 }
+
+func TestLoader_Load_RejectsWildcardEnvForward(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+agents:
+  claude-code:
+    env_forward:
+      - "*"
+`), 0o644))
+
+	loader := NewLoader(path)
+	_, err := loader.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validating config file")
+	assert.Contains(t, err.Error(), "agents.claude-code")
+	assert.Contains(t, err.Error(), `bare "*"`)
+}
+
+func TestLoadFromPath_RejectsWildcardEnvForward(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".broodbox.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+agents:
+  claude-code:
+    env_forward:
+      - "*"
+`), 0o644))
+
+	_, err := LoadFromPath(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validating config file")
+	assert.Contains(t, err.Error(), `bare "*"`)
+}
+
+func TestLoadFromPath_RejectsEmptyEnvForward(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".broodbox.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+agents:
+  claude-code:
+    env_forward:
+      - ""
+`), 0o644))
+
+	_, err := LoadFromPath(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty pattern")
+}

--- a/pkg/domain/agent/env.go
+++ b/pkg/domain/agent/env.go
@@ -4,8 +4,45 @@
 package agent
 
 import (
+	"fmt"
 	"strings"
 )
+
+// ValidateEnvForwardPatterns rejects env-forward patterns that would
+// match every (or no) host environment variable. Specifically:
+//
+//   - An empty / whitespace-only pattern matches the empty string key,
+//     which is never a real env var but is also clearly a typo.
+//   - A bare "*" (or whitespace-trimmed "*") matches every key because
+//     its trimmed prefix is the empty string — this is a blanket
+//     "forward everything" that lets an untrusted workspace config
+//     or a footgun CLI flag scoop up secrets like SSH_AUTH_SOCK,
+//     GITHUB_TOKEN, AWS_*, etc., without the operator knowing.
+//   - A leading-star pattern like "*_API_KEY" is silently useless
+//     (only trailing-star globs are honored by matchPattern). Reject
+//     it with a clear error so users learn the correct syntax.
+//
+// Explicit exact names ("HOME") and trailing-star globs with a
+// non-empty prefix ("AWS_*", "CARGO_*") are always accepted.
+//
+// Callers should apply this to every user-supplied source:
+// global config, workspace-local config, and CLI flags. The matcher
+// also defensively skips empty/bare-"*" patterns at evaluation time.
+func ValidateEnvForwardPatterns(patterns []string) error {
+	for i, p := range patterns {
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
+			return fmt.Errorf("env_forward[%d]: empty pattern — specify an exact name or a prefix like \"AWS_*\"", i)
+		}
+		if trimmed == "*" {
+			return fmt.Errorf("env_forward[%d]: bare \"*\" matches every host env var — specify an exact name or a prefix like \"AWS_*\"", i)
+		}
+		if strings.HasPrefix(trimmed, "*") {
+			return fmt.Errorf("env_forward[%d]: leading-star patterns are not supported (%q) — only trailing-star globs like \"AWS_*\"", i, trimmed)
+		}
+	}
+	return nil
+}
 
 // EnvProvider abstracts access to environment variables for testability.
 type EnvProvider interface {
@@ -70,9 +107,21 @@ func matchesAny(key string, patterns []string) bool {
 
 // matchPattern checks if key matches the pattern.
 // Supports exact match and glob suffix (e.g., "CLAUDE_*").
+//
+// Defense-in-depth: an empty pattern or a bare "*" (after whitespace
+// trimming) is never a match — callers should reject these via
+// ValidateEnvForwardPatterns at load time, but this guard makes sure a
+// bypass cannot silently forward every host env var.
 func matchPattern(key, pattern string) bool {
+	trimmed := strings.TrimSpace(pattern)
+	if trimmed == "" || trimmed == "*" {
+		return false
+	}
 	if strings.HasSuffix(pattern, "*") {
 		prefix := strings.TrimSuffix(pattern, "*")
+		if prefix == "" {
+			return false
+		}
 		return strings.HasPrefix(key, prefix)
 	}
 	return key == pattern

--- a/pkg/domain/agent/env_test.go
+++ b/pkg/domain/agent/env_test.go
@@ -112,6 +112,61 @@ func TestForwardEnv(t *testing.T) {
 	}
 }
 
+func TestValidateEnvForwardPatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		patterns []string
+		wantErr  bool
+		errSub   string // substring the error must contain
+	}{
+		{name: "empty list is fine", patterns: nil, wantErr: false},
+		{name: "exact names pass", patterns: []string{"HOME", "USER", "GITHUB_TOKEN"}, wantErr: false},
+		{name: "trailing glob passes", patterns: []string{"AWS_*", "CLAUDE_*"}, wantErr: false},
+		{name: "mixed exact and glob", patterns: []string{"HOME", "AWS_*"}, wantErr: false},
+
+		{name: "bare star rejected", patterns: []string{"*"}, wantErr: true, errSub: "bare \"*\""},
+		{name: "bare star with surrounding whitespace rejected", patterns: []string{"  *  "}, wantErr: true, errSub: "bare \"*\""},
+		{name: "empty string rejected", patterns: []string{""}, wantErr: true, errSub: "empty pattern"},
+		{name: "whitespace-only rejected", patterns: []string{"   "}, wantErr: true, errSub: "empty pattern"},
+		{name: "leading star rejected", patterns: []string{"*_API_KEY"}, wantErr: true, errSub: "leading-star"},
+		{name: "bare star mixed with valid patterns still rejects", patterns: []string{"HOME", "*"}, wantErr: true, errSub: "bare \"*\""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateEnvForwardPatterns(tt.patterns)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errSub != "" {
+					assert.Contains(t, err.Error(), tt.errSub)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMatchPattern_DefensiveBypassGuard(t *testing.T) {
+	t.Parallel()
+
+	// Even if ValidateEnvForwardPatterns is bypassed (e.g. by a caller
+	// constructing patterns programmatically), matchPattern must NOT
+	// let a bare "*" or empty pattern swallow every key.
+	keys := []string{"HOME", "GITHUB_TOKEN", "SSH_AUTH_SOCK", "AWS_ACCESS_KEY_ID", ""}
+	bad := []string{"*", "", "   ", "  *  "}
+
+	for _, pattern := range bad {
+		for _, key := range keys {
+			assert.False(t, matchPattern(key, pattern),
+				"pattern %q must not match key %q", pattern, key)
+		}
+	}
+}
+
 func TestShellEscape(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/domain/config/config.go
+++ b/pkg/domain/config/config.go
@@ -50,6 +50,26 @@ type Config struct {
 	Agents map[string]AgentOverride `yaml:"agents"`
 }
 
+// Validate checks user-supplied fields for footguns that must be
+// rejected at load time. Today this scope is narrow:
+//
+//   - Per-agent env_forward patterns cannot be a bare "*" / empty /
+//     leading-star — see agent.ValidateEnvForwardPatterns for the full
+//     rationale. Applies to both the global and the workspace-local
+//     config (each gets validated at its own load site).
+//
+// Other validation lives with the types it guards (e.g. MCPFileConfig
+// has its own Validate). Add more here as new classes of footgun
+// emerge.
+func (c *Config) Validate() error {
+	for name, override := range c.Agents {
+		if err := agent.ValidateEnvForwardPatterns(override.EnvForward); err != nil {
+			return fmt.Errorf("agents.%s.%w", name, err)
+		}
+	}
+	return nil
+}
+
 // GitConfig configures git identity and authentication forwarding
 // into the sandbox VM.
 type GitConfig struct {

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -260,6 +260,14 @@ func (s *SandboxRunner) Prepare(ctx context.Context, agentName string, opts RunO
 		return nil, fmt.Errorf("session ID must be 1-16 hex characters, got %q", opts.SessionID)
 	}
 
+	// Validate SDK-supplied env-forward patterns. The CLI validates the
+	// --env-forward flag in run(), but SDK consumers constructing RunOpts
+	// directly bypass that path. Re-check here so the footgun is closed
+	// at the SDK boundary too.
+	if err := agent.ValidateEnvForwardPatterns(opts.EnvForwardExtra); err != nil {
+		return nil, fmt.Errorf("invalid EnvForwardExtra: %w", err)
+	}
+
 	// 1. Resolve agent from registry.
 	s.observer.Start(progress.PhaseResolvingAgent, "Resolving agent...")
 	ag, err := s.registry.Get(agentName)


### PR DESCRIPTION
## Summary

Closes a HIGH security finding. A bare `*` in `env_forward` (global config, workspace `.broodbox.yaml`, or `--env-forward` CLI flag) matched every host environment variable because `matchPattern` trimmed the trailing `*` and then `HasPrefix(key, "")` was always true. Combined with `mergeAgentOverride` replacing the global value with the workspace-local value verbatim, a malicious `.broodbox.yaml` could ship `agents.claude-code.env_forward: ["*"]` and scoop up host secrets (`SSH_AUTH_SOCK`, `GITHUB_TOKEN`, `AWS_*`, `VAULT_TOKEN`, `OKTA_*`) into the guest agent's environment — from where any permitted egress host becomes an exfiltration channel.

The narrow fix preserves the feature (per-repo allowlists like `["GOFLAGS", "CARGO_*"]` are legitimate and useful) while rejecting three classes of footgun:

- Bare `*` and whitespace-trimmed variants
- Empty / whitespace-only patterns
- Leading-star (`*_KEY`) — silently useless today; surface a clear error so users learn the correct syntax

### Validation coverage

Validation runs at four load points so no user-supplied source bypasses it:

- `NewLoader.Load` — global `~/.config/broodbox/config.yaml`
- `LoadFromPath` — workspace-local `.broodbox.yaml`
- `run()` — `--env-forward` CLI flag
- `SandboxRunner.Prepare` — SDK boundary (`RunOpts.EnvForwardExtra`)

Defense-in-depth: `matchPattern` also returns false for empty / bare-`*` patterns so a bypass of load-time validation cannot silently forward every env var.

### UX change

Global config load errors are now fatal instead of warn-and-fall-back-to-defaults. Silently discarding every override in a user's own config because one line fails validation was worse UX than a clear error naming the file and the exact problem. Workspace-local config keeps its warn-and-skip behavior so a malicious repo cannot DOS a user's session.

### Error messages

Every rejection pinpoints the location and suggests the fix:
- `loading global config /path/to/config.yaml: validating config file ...: agents.claude-code.env_forward[0]: bare "*" matches every host env var — specify an exact name or a prefix like "AWS_*"`
- `invalid --env-forward: env_forward[0]: leading-star patterns are not supported ("*_API_KEY") — only trailing-star globs like "AWS_*"`

## Test plan

- [x] `task fmt && task lint && task test` — all green
- [x] Unit tests cover the validator directly (exact names, trailing globs, bare `*` variants, empty, whitespace, leading-star, mixed-with-valid patterns)
- [x] Integration tests exercise global `Loader.Load`, workspace `LoadFromPath`, and empty-string in config
- [x] Defensive `matchPattern` test: bad patterns (`"*"`, `""`, `"   "`, `"  *  "`) must not match any realistic env var name including `SSH_AUTH_SOCK`, `GITHUB_TOKEN`, `AWS_ACCESS_KEY_ID`
- [x] Headless end-to-end:
  - `bbox claude-code --env-forward '*'` → exit non-zero with clear error
  - `bbox claude-code --env-forward '*_API_KEY'` → exit non-zero with clear error
  - `bbox claude-code --config /path/with-star.yaml` → exit non-zero with file path in error
  - `bbox claude-code --no-mcp --env-forward HOME --exec /bin/sh -- -c 'env | grep ^HOME='` → VM boots, `HOME` forwarded, `AWS_*`/`GITHUB_TOKEN`/`ANTHROPIC_API_KEY` NOT present

🤖 Generated with [Claude Code](https://claude.com/claude-code)