### PR TITLE
Harden config file loading: size cap, strict fields, symlink reject

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -299,6 +299,22 @@ review:
 Note: `review.enabled` is **ignored** in per-workspace config for security
 (use `--no-review` explicitly).
 
+**File rules for `.broodbox.yaml`:**
+
+- Must be a regular file — symlinks, FIFOs, and device files are
+  rejected because the workspace path is repo-controllable. To share
+  a template across projects, copy the file into each workspace
+  instead of symlinking.
+- Must be under 1 MiB. Real configs are a few KiB; the cap only
+  bounds DoS from a malformed input.
+- Unknown top-level fields are a parse error. A typo like
+  `mcp.athz.profile: observe` (should be `authz`) fails loudly
+  rather than silently falling back to the permissive default.
+- If `.broodbox.yaml` fails to load, bbox prints a warning to stderr
+  and continues with just the global config, so a bad workspace file
+  cannot block a session. The warning names the file and the specific
+  problem.
+
 ## Egress Firewall
 
 Each agent comes with DNS-aware egress policies. Three profiles are available:

--- a/internal/infra/config/loader.go
+++ b/internal/infra/config/loader.go
@@ -7,12 +7,12 @@ package config
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 
-	"gopkg.in/yaml.v3"
-
+	"github.com/stacklok/brood-box/internal/infra/configfile"
 	domainconfig "github.com/stacklok/brood-box/pkg/domain/config"
 )
 
@@ -34,7 +34,7 @@ func NewLoader(path string) *Loader {
 // Load reads and parses the config file. If the file does not exist,
 // it returns a zero-value Config (no error).
 func (l *Loader) Load() (*domainconfig.Config, error) {
-	data, err := os.ReadFile(l.path)
+	data, err := configfile.ReadFile(l.path, configfile.ReadOptions{})
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return &domainconfig.Config{}, nil
@@ -43,7 +43,10 @@ func (l *Loader) Load() (*domainconfig.Config, error) {
 	}
 
 	var cfg domainconfig.Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := configfile.DecodeStrict(data, &cfg); err != nil {
+		if errors.Is(err, io.EOF) {
+			return &domainconfig.Config{}, nil
+		}
 		return nil, fmt.Errorf("parsing config file %s: %w", l.path, err)
 	}
 
@@ -59,11 +62,16 @@ func (l *Loader) Path() string {
 	return l.path
 }
 
-// LoadFromPath reads and parses a config file at the given path.
+// LoadFromPath reads and parses a workspace-local config file at the
+// given path. Workspace-local hardening applies: symlinks are rejected
+// because the path is attacker-controllable (a malicious repo's
+// `.broodbox.yaml` could otherwise be a symlink to another readable
+// file on the host).
+//
 // Returns (nil, nil) when the file does not exist.
 // Returns a parsed Config for any existing file (including empty files).
 func LoadFromPath(path string) (*domainconfig.Config, error) {
-	data, err := os.ReadFile(path)
+	data, err := configfile.ReadFile(path, configfile.ReadOptions{RejectSymlinks: true})
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil
@@ -72,7 +80,10 @@ func LoadFromPath(path string) (*domainconfig.Config, error) {
 	}
 
 	var cfg domainconfig.Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := configfile.DecodeStrict(data, &cfg); err != nil {
+		if errors.Is(err, io.EOF) {
+			return &domainconfig.Config{}, nil
+		}
 		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
 	}
 

--- a/internal/infra/config/loader_test.go
+++ b/internal/infra/config/loader_test.go
@@ -6,7 +6,9 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -199,4 +201,114 @@ agents:
 	_, err := LoadFromPath(path)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty pattern")
+}
+
+func TestLoadFromPath_RejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	// `mcp.athz.profile` (typo for `mcp.authz.profile`) must not be
+	// silently dropped — that would let a repo author *think* they've
+	// tightened to `observe` while the operator falls back to
+	// `full-access`.
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".broodbox.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+mcp:
+  athz:
+    profile: observe
+`), 0o644))
+
+	_, err := LoadFromPath(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing config file")
+}
+
+func TestLoader_Load_RejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+nonexistent_top_level: true
+`), 0o644))
+
+	loader := NewLoader(path)
+	_, err := loader.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing config file")
+}
+
+func TestLoadFromPath_RejectsOversizedFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".broodbox.yaml")
+	// 2 MiB of padded YAML comments — exceeds the 1 MiB cap.
+	big := make([]byte, 2*1024*1024)
+	for i := range big {
+		big[i] = '#'
+	}
+	require.NoError(t, os.WriteFile(path, big, 0o644))
+
+	_, err := LoadFromPath(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+func TestLoadFromPath_RejectsSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.yaml")
+	require.NoError(t, os.WriteFile(target, []byte("defaults:\n  cpus: 2\n"), 0o644))
+
+	linkPath := filepath.Join(dir, ".broodbox.yaml")
+	require.NoError(t, os.Symlink(target, linkPath))
+
+	_, err := LoadFromPath(linkPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlinks are not allowed")
+}
+
+func TestLoadFromPath_RejectsNonRegularFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".broodbox.yaml")
+	// A FIFO (named pipe) is the realistic non-regular case: `os.Open`
+	// without a writer blocks forever. Must be rejected up-front.
+	require.NoError(t, syscall.Mkfifo(path, 0o600))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := LoadFromPath(path)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a regular file")
+	case <-time.After(5 * time.Second):
+		t.Fatal("LoadFromPath blocked on FIFO — should have rejected it immediately")
+	}
+}
+
+func TestLoader_Load_FollowsSymlink(t *testing.T) {
+	t.Parallel()
+
+	// The global-config path is operator-supplied — symlinks are a
+	// legitimate operator choice (e.g. pointing at a team-shared file),
+	// so they must NOT be rejected on the Load path.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.yaml")
+	require.NoError(t, os.WriteFile(target, []byte("defaults:\n  cpus: 3\n"), 0o644))
+
+	linkPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.Symlink(target, linkPath))
+
+	loader := NewLoader(linkPath)
+	cfg, err := loader.Load()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(3), cfg.Defaults.CPUs)
 }

--- a/internal/infra/configfile/reader.go
+++ b/internal/infra/configfile/reader.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package configfile provides hardened file reading and YAML decoding
+// primitives shared by brood-box's config loaders (global config,
+// workspace `.broodbox.yaml`, MCP vmcp config).
+//
+// All three loaders want the same three things: a size cap (so a
+// gigantic YAML cannot OOM bbox before it can report an error), strict
+// unknown-field checking (so security-sensitive typos like
+// `mcp.athz.profile: observe` fail loudly rather than silently falling
+// back to a permissive default), and — for workspace-local files only
+// — rejection of symlinks (so a malicious repo cannot point
+// `.broodbox.yaml` at an arbitrary readable file on the host).
+package configfile
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MaxSize is the cap on config file size in bytes. Real broodbox
+// configs are single-digit KiB; 1 MiB is generous.
+const MaxSize int64 = 1 << 20
+
+// ReadOptions controls the hardening applied when reading a config
+// file. The zero value (no workspace-local hardening) is appropriate
+// for operator-supplied paths (global config, --mcp-config flag).
+type ReadOptions struct {
+	// RejectSymlinks, when true, refuses to read a file whose final
+	// path component is a symlink. Use for workspace-local config
+	// files (e.g. `.broodbox.yaml`) whose path is attacker-controllable.
+	RejectSymlinks bool
+}
+
+// ReadFile reads a config file with a size cap and, optionally,
+// symlink rejection. Errors wrap fs.ErrNotExist when the file is
+// absent so callers can distinguish missing from failing.
+//
+// Non-regular files (FIFOs, sockets, device nodes) are always
+// rejected. Opening a FIFO without a writer would block indefinitely
+// and produce no useful error, so a malicious or accidental FIFO at
+// the config path fails cleanly instead of hanging bbox.
+func ReadFile(path string, opts ReadOptions) ([]byte, error) {
+	if opts.RejectSymlinks {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return nil, err
+		}
+		mode := info.Mode()
+		if mode&os.ModeSymlink != 0 {
+			target, _ := os.Readlink(path)
+			return nil, fmt.Errorf(
+				"refusing to load %s: symlinks are not allowed for workspace-local config (points to %q)",
+				path, target)
+		}
+		if !mode.IsRegular() {
+			return nil, fmt.Errorf(
+				"refusing to load %s: not a regular file (mode=%s)",
+				path, mode)
+		}
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf(
+			"config file %s is not a regular file (mode=%s)",
+			path, info.Mode())
+	}
+	if info.Size() > MaxSize {
+		return nil, fmt.Errorf(
+			"config file %s is too large: %d bytes (limit %d)",
+			path, info.Size(), MaxSize)
+	}
+
+	// LimitReader as belt-and-braces in case the size changes between
+	// stat and read (rare for local files, but the cost is trivial).
+	return io.ReadAll(io.LimitReader(f, MaxSize))
+}
+
+// DecodeStrict decodes YAML into out with strict unknown-field
+// checking. A YAML key that does not correspond to a field on the
+// target struct — for example a misspelled `mcp.athz.profile` instead
+// of `mcp.authz.profile` — returns an error naming the offending key
+// and the line number it appears on, rather than silently being
+// dropped and letting the operator's intended tightening fail open.
+func DecodeStrict(data []byte, out any) error {
+	d := yaml.NewDecoder(bytes.NewReader(data))
+	d.KnownFields(true)
+	return d.Decode(out)
+}

--- a/internal/infra/mcp/configloader.go
+++ b/internal/infra/mcp/configloader.go
@@ -6,18 +6,20 @@ package mcp
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
-	"os"
 
-	"gopkg.in/yaml.v3"
-
+	"github.com/stacklok/brood-box/internal/infra/configfile"
 	domainconfig "github.com/stacklok/brood-box/pkg/domain/config"
 )
 
-// LoadMCPFileConfig reads and validates an MCP config from a YAML file.
+// LoadMCPFileConfig reads and validates an MCP config from a YAML file
+// supplied via the operator's --mcp-config flag. Operator-owned paths
+// skip the workspace-local symlink rejection but still get the size
+// cap and strict-unknown-fields checking.
 // Returns (nil, nil) if the file does not exist.
 func LoadMCPFileConfig(path string) (*domainconfig.MCPFileConfig, error) {
-	data, err := os.ReadFile(path)
+	data, err := configfile.ReadFile(path, configfile.ReadOptions{})
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil
@@ -26,7 +28,10 @@ func LoadMCPFileConfig(path string) (*domainconfig.MCPFileConfig, error) {
 	}
 
 	var cfg domainconfig.MCPFileConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := configfile.DecodeStrict(data, &cfg); err != nil {
+		if errors.Is(err, io.EOF) {
+			return &domainconfig.MCPFileConfig{}, nil
+		}
 		return nil, fmt.Errorf("parsing MCP config %s: %w", path, err)
 	}
 

--- a/internal/infra/mcp/configloader_test.go
+++ b/internal/infra/mcp/configloader_test.go
@@ -132,6 +132,39 @@ func TestLoadMCPFileConfig_EmptyFile(t *testing.T) {
 	assert.Nil(t, cfg.Aggregation)
 }
 
+func TestLoadMCPFileConfig_RejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	// `authz.polices` (typo for `policies`) must not be silently
+	// dropped — otherwise the operator would end up with no Cedar
+	// policies and a silently open custom profile.
+	content := `
+authz:
+  polices:
+    - 'permit(principal, action, resource);'
+`
+	path := writeTestFile(t, content)
+	_, err := LoadMCPFileConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing MCP config")
+}
+
+func TestLoadMCPFileConfig_RejectsOversizedFile(t *testing.T) {
+	t.Parallel()
+
+	big := make([]byte, 2*1024*1024)
+	for i := range big {
+		big[i] = '#'
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp-config.yaml")
+	require.NoError(t, os.WriteFile(path, big, 0o600))
+
+	_, err := LoadMCPFileConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
 func writeTestFile(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Closes a LOW security finding with three parts. The config loaders (global `~/.config/broodbox/config.yaml`, workspace `.broodbox.yaml`, `--mcp-config` file) previously:

1. **Had no size cap** — a 2 GiB malicious `.broodbox.yaml` would OOM bbox before it could warn.
2. **Silently dropped unknown YAML fields** — a typo like `mcp.athz.profile: observe` (should be `authz`) failed open to `full-access`. Security-critical typos fell back to permissive defaults with no error.
3. **Followed symlinks for the workspace-local config** — a malicious repo could point `.broodbox.yaml` at any readable path on the host.

## Changes

New `internal/infra/configfile` package with `ReadFile` (1 MiB cap, optional symlink reject, non-regular-file reject) and `DecodeStrict` (`yaml.Decoder.KnownFields(true)`). Three loaders wire it in:

| Loader | Size cap | Strict fields | Symlink reject | Rationale |
|---|---|---|---|---|
| `Loader.Load` (global) | ✓ | ✓ | — | Operator owns the path; symlink to a team dotfiles dir is legitimate |
| `LoadFromPath` (workspace) | ✓ | ✓ | ✓ | Repo controls the path; all hardening applies |
| `LoadMCPFileConfig` (`--mcp-config`) | ✓ | ✓ | — | Operator-supplied CLI flag |

Plus one UX-safety addition flagged by reviews: **all three loaders reject non-regular files** (FIFOs, sockets, device nodes). Without this, a FIFO planted at `.broodbox.yaml` would cause `os.Open` to block indefinitely waiting for a writer, hanging bbox with no error.

**Error-handling stays asymmetric** (established in prior PR): global config errors are fatal (user owns the file); workspace errors are warn-and-skip (malicious repo cannot DOS the session).

**Docs**: extended `docs/USER_GUIDE.md` section on per-workspace config with the new file rules so users hitting the symlink rejection know to copy templates instead of linking.

## Test plan

- [x] `task fmt && task lint && task test` — all green
- [x] Unit tests for each hardening: typo rejection (`mcp.athz.profile`), oversized file (2 MiB), workspace symlink, FIFO at workspace path, MCP config typo/oversized
- [x] Negative control: global config symlinked to a regular file still loads
- [x] Headless end-to-end:
  - `.broodbox.yaml` typo → `Warning: failed to load local config ...: parsing config file ...: yaml: unmarshal errors: line N: field athz not found` (bbox continues with global)
  - Oversized `.broodbox.yaml` → `Warning: ...: config file ... is too large: 2097152 bytes (limit 1048576)` (bbox continues)
  - `.broodbox.yaml` symlink → `Warning: ...: symlinks are not allowed for workspace-local config (points to "target.yaml")` (bbox continues)
  - FIFO at `.broodbox.yaml` → `Warning: ...: not a regular file (mode=prw-r--r--)` (bbox continues; **does not hang**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)