### PR TITLE
Use O_NOFOLLOW on file writes: flusher, credential, settings

### DIFF
--- a/internal/infra/credential/store.go
+++ b/internal/infra/credential/store.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/stacklok/brood-box/internal/infra/safeio"
 	"github.com/stacklok/brood-box/pkg/domain/credential"
 )
 
@@ -119,7 +120,10 @@ func (s *FSStore) injectFile(src, dst string) error {
 	}
 	defer func() { _ = sf.Close() }()
 
-	df, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePerm)
+	// O_NOFOLLOW: refuse to follow a pre-existing symlink at dst.
+	// A malicious or buggy base image could otherwise redirect
+	// credential writes out of the rootfs to an attacker-chosen path.
+	df, err := safeio.OpenForWrite(dst, filePerm)
 	if err != nil {
 		return fmt.Errorf("creating destination: %w", err)
 	}

--- a/internal/infra/review/flusher.go
+++ b/internal/infra/review/flusher.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/stacklok/brood-box/internal/infra/diff"
+	"github.com/stacklok/brood-box/internal/infra/safeio"
 	infraws "github.com/stacklok/brood-box/internal/infra/workspace"
 	"github.com/stacklok/brood-box/pkg/domain/snapshot"
 )
@@ -88,7 +89,9 @@ func (f *FSFlusher) Flush(originalDir, snapshotDir string, accepted []snapshot.F
 }
 
 // copyFilePreserveMode copies src to dst preserving file permissions.
-// Setuid/setgid bits are stripped for security.
+// Setuid/setgid bits are stripped for security. The destination is
+// opened with O_NOFOLLOW: if dst is a pre-existing symlink, the open
+// fails cleanly rather than writing through to the symlink's target.
 func copyFilePreserveMode(src, dst string) error {
 	sf, err := os.Open(src)
 	if err != nil {
@@ -104,7 +107,7 @@ func copyFilePreserveMode(src, dst string) error {
 	// Strip setuid/setgid/sticky bits — only preserve rwx permissions.
 	mode := info.Mode().Perm()
 
-	df, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	df, err := safeio.OpenForWrite(dst, mode)
 	if err != nil {
 		return err
 	}

--- a/internal/infra/review/flusher_test.go
+++ b/internal/infra/review/flusher_test.go
@@ -235,3 +235,37 @@ func TestFSFlusher_DeletedFile_WithHashVerification(t *testing.T) {
 	_, err = os.Stat(origFile)
 	assert.True(t, os.IsNotExist(err), "file should be deleted")
 }
+
+func TestFSFlusher_RefusesToWriteThroughSymlink(t *testing.T) {
+	t.Parallel()
+
+	origDir := t.TempDir()
+	snapDir := t.TempDir()
+
+	// In-workspace symlink redirect: `link.txt -> real-target.txt`.
+	// ValidateInBounds accepts because the resolved target is inside
+	// the workspace, but the O_NOFOLLOW open in copyFilePreserveMode
+	// still refuses to write through the symlink — otherwise an
+	// agent editing what it thinks is "link.txt" would silently
+	// overwrite `real-target.txt`.
+	target := filepath.Join(origDir, "real-target.txt")
+	require.NoError(t, os.WriteFile(target, []byte("do-not-clobber"), 0o600))
+	require.NoError(t, os.Symlink("real-target.txt", filepath.Join(origDir, "link.txt")))
+
+	// Snapshot has the "modified" version.
+	require.NoError(t, os.WriteFile(filepath.Join(snapDir, "link.txt"), []byte("agent-modified"), 0o644))
+	hash, err := diff.HashFile(filepath.Join(snapDir, "link.txt"))
+	require.NoError(t, err)
+
+	flusher := NewFSFlusher()
+	err = flusher.Flush(origDir, snapDir, []snapshot.FileChange{
+		{RelPath: "link.txt", Kind: snapshot.Modified, Hash: hash},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+
+	// The symlink's target must NOT have been clobbered.
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("do-not-clobber"), got)
+}

--- a/internal/infra/safeio/write.go
+++ b/internal/infra/safeio/write.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package safeio provides defensive file-I/O primitives. Today its
+// single concern is opening files for write WITHOUT following
+// symlinks at the final path component, so a pre-existing symlink
+// cannot redirect a write to an unintended target.
+//
+// This matters in three brood-box flows:
+//
+//   - The flusher writes from the snapshot back to the host workspace.
+//     A symlink at the destination (either user-planted or a TOCTOU
+//     race) would otherwise cause bbox to overwrite whatever the
+//     symlink points at (worst case: ~/.ssh/authorized_keys).
+//
+//   - The credential store writes credentials into the VM rootfs. A
+//     malicious or buggy base image containing pre-existing symlinks
+//     could otherwise redirect a credential write out of the rootfs.
+//
+//   - The settings injector writes per-agent settings (Claude Code's
+//     ~/.claude/*, opencode's ~/.config/opencode/*) into the VM
+//     rootfs. Same concern as the credential store.
+//
+// In each case the destination path is path-component-controlled by
+// brood-box, but the final inode may not be: O_NOFOLLOW ensures the
+// open fails cleanly with ELOOP rather than silently traversing.
+//
+// Scope note: O_NOFOLLOW only covers the final path component. A
+// symlinked parent directory is still resolved normally — that layer
+// is the responsibility of the caller's containment check
+// (ValidateInBounds, validateContainment) rather than safeio. This
+// matches POSIX semantics and is documented here so callers do not
+// over-rely on safeio for defense-in-depth that only the full layering
+// provides.
+package safeio
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// OpenForWrite opens path for writing with create-or-truncate
+// semantics, refusing to follow a symlink at the final path
+// component. If path IS a symlink, open fails with syscall.ELOOP
+// wrapped in a clear error.
+//
+// The caller owns the returned *os.File and is responsible for Close.
+func OpenForWrite(path string, mode os.FileMode) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|syscall.O_NOFOLLOW, mode)
+	if err != nil {
+		return nil, wrapSymlinkError(path, err)
+	}
+	return f, nil
+}
+
+// WriteFileNoFollow is the O_NOFOLLOW equivalent of os.WriteFile:
+// it writes data to path with create-or-truncate semantics, refusing
+// to follow a symlink at the final path component.
+func WriteFileNoFollow(path string, data []byte, mode os.FileMode) error {
+	f, err := OpenForWrite(path, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// wrapSymlinkError augments an ELOOP error with a clear message so
+// users hitting the rejection (via a symlink in their workspace or
+// a base image) can tell what happened, what the symlink points at,
+// and how to recover.
+func wrapSymlinkError(path string, err error) error {
+	if !isSymlinkError(err) {
+		return err
+	}
+	target, linkErr := os.Readlink(path)
+	if linkErr != nil || target == "" {
+		return fmt.Errorf("%s: refusing to follow symlink — edit the target file directly or add the path to .broodboxignore", path)
+	}
+	return fmt.Errorf("%s: refusing to follow symlink to %q — edit that file directly or add the path to .broodboxignore", path, target)
+}
+
+// isSymlinkError reports whether err indicates that an O_NOFOLLOW
+// open failed because the final path component is a symlink. Both
+// Linux and Darwin return ELOOP from open(2) in this case (per the
+// POSIX spec); we check both via errors.As unwrapping the
+// syscall.Errno out of *os.PathError.
+func isSymlinkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	return errno == syscall.ELOOP
+}

--- a/internal/infra/safeio/write_test.go
+++ b/internal/infra/safeio/write_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package safeio
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteFileNoFollow_CreatesNewFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.txt")
+
+	require.NoError(t, WriteFileNoFollow(path, []byte("hello"), 0o600))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), got)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestWriteFileNoFollow_TruncatesExisting(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.txt")
+	require.NoError(t, os.WriteFile(path, []byte("original-long-content"), 0o600))
+
+	require.NoError(t, WriteFileNoFollow(path, []byte("short"), 0o600))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("short"), got)
+}
+
+func TestWriteFileNoFollow_RejectsSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	require.NoError(t, os.WriteFile(target, []byte("target-content"), 0o600))
+
+	link := filepath.Join(dir, "link.txt")
+	require.NoError(t, os.Symlink(target, link))
+
+	err := WriteFileNoFollow(link, []byte("overwrite"), 0o600)
+	require.Error(t, err)
+	// Error names the symlink target so users can tell what bbox
+	// would have overwritten.
+	assert.Contains(t, err.Error(), "symlink")
+	assert.Contains(t, err.Error(), target)
+	// Error mentions .broodboxignore as a recovery path.
+	assert.Contains(t, err.Error(), ".broodboxignore")
+
+	// Target must NOT have been overwritten.
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("target-content"), got)
+}
+
+func TestWriteFileNoFollow_RejectsSymlinkToNonexistent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Symlink pointing at a path that does not exist.
+	link := filepath.Join(dir, "dangling.txt")
+	require.NoError(t, os.Symlink("/nonexistent/target", link))
+
+	err := WriteFileNoFollow(link, []byte("overwrite"), 0o600)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink")
+	// Target name is still surfaced even when it does not exist.
+	assert.Contains(t, err.Error(), "/nonexistent/target")
+}
+
+func TestOpenForWrite_RegularFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "regular.txt")
+
+	f, err := OpenForWrite(path, 0o600)
+	require.NoError(t, err)
+	_, writeErr := f.Write([]byte("via OpenForWrite"))
+	closeErr := f.Close()
+	require.NoError(t, writeErr)
+	require.NoError(t, closeErr)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("via OpenForWrite"), got)
+}

--- a/internal/infra/settings/injector.go
+++ b/internal/infra/settings/injector.go
@@ -19,6 +19,7 @@ import (
 
 	toml "github.com/pelletier/go-toml/v2"
 
+	"github.com/stacklok/brood-box/internal/infra/safeio"
 	"github.com/stacklok/brood-box/pkg/domain/settings"
 )
 
@@ -172,7 +173,10 @@ func (f *FSInjector) extractFile(
 		return fmt.Errorf("creating parent dirs: %w", err)
 	}
 
-	if err := os.WriteFile(dstPath, data, filePerm); err != nil {
+	// O_NOFOLLOW: a pre-existing symlink at the host settings path
+	// would otherwise let the guest redirect an extraction write to
+	// an attacker-chosen target.
+	if err := safeio.WriteFileNoFollow(dstPath, data, filePerm); err != nil {
 		return fmt.Errorf("writing host file: %w", err)
 	}
 
@@ -331,7 +335,9 @@ func (f *FSInjector) injectFile(
 	}
 	bestEffortChown(f.logger, filepath.Dir(dstPath))
 
-	if err := os.WriteFile(dstPath, data, filePerm); err != nil {
+	// O_NOFOLLOW: refuse to follow a pre-existing symlink planted by
+	// a malicious or buggy guest base image.
+	if err := safeio.WriteFileNoFollow(dstPath, data, filePerm); err != nil {
 		return fmt.Errorf("writing destination: %w", err)
 	}
 	bestEffortChown(f.logger, dstPath)
@@ -518,7 +524,9 @@ func (f *FSInjector) injectMergeFile(
 	}
 	bestEffortChown(f.logger, filepath.Dir(dstPath))
 
-	if err := os.WriteFile(dstPath, output, filePerm); err != nil {
+	// O_NOFOLLOW: same concern as the plain-copy path above — a
+	// symlink in the guest rootfs could redirect this merged write.
+	if err := safeio.WriteFileNoFollow(dstPath, output, filePerm); err != nil {
 		return fmt.Errorf("writing merged file: %w", err)
 	}
 	bestEffortChown(f.logger, dstPath)


### PR DESCRIPTION
## Summary

Closes a MEDIUM security finding about destination symlink-follow on three write sites. `os.OpenFile`/`os.WriteFile` without `O_NOFOLLOW` lets a pre-existing symlink at the destination silently redirect the write to an attacker-chosen target.

New `internal/infra/safeio` package with `OpenForWrite` and `WriteFileNoFollow`. Three call sites migrated:

- **Flusher** (`internal/infra/review/flusher.go`) — snapshot → host workspace.
- **Credential store** (`internal/infra/credential/store.go`) — host → VM rootfs.
- **Settings injector** (`internal/infra/settings/injector.go`) — both directions, three sites.

## Clarifying the flusher threat model

The common case of "user has a symlink in their workspace that the agent edits" is **unaffected**. The snapshot cloner preserves symlinks, writes inside the VM resolve through them to regular target files, and the differ attributes the change to the target path (not the symlink path). The O_NOFOLLOW in the flusher is defense-in-depth for narrow scenarios — a symlink smuggled past the differ's non-regular-file filter, or a TOCTOU race planting a symlink between diff and flush.

Verified by end-to-end smoke: a workspace with `alias.txt -> real-target.txt` has the agent's edit to `alias.txt` correctly flushed to `real-target.txt` (the resolved target), no rejection.

## Error message (when O_NOFOLLOW does trigger)

```
/path/to/file: refusing to follow symlink to "target" — edit that file directly or add the path to .broodboxignore
```

Names the target (so users know what bbox would have overwritten) and both recovery paths.

## Test plan

- [x] `task fmt && task lint && task test` — all green
- [x] `safeio` unit tests: creates new, truncates existing, rejects symlink (with target name in error), rejects dangling symlink, raw `OpenForWrite` exercises the happy path
- [x] `TestFSFlusher_RefusesToWriteThroughSymlink`: in-workspace symlink redirect is caught by O_NOFOLLOW after `ValidateInBounds` passes, and the target file is verified untouched
- [x] Full e2e: legitimate workspace with a symlink; agent modifies the file; flush correctly updates the resolved target; no rejection

## Follow-ups (not in this PR)

- Additional write sites in `internal/infra/vm/*` (knownhosts, gitconfig, mcpconfig, hooks) have the same exposure class and should migrate to `safeio`.
- Flusher's src-side open still follows symlinks; the narrow TOCTOU window between `HashFile` and `os.Open` on `snapPath` is unchanged by this patch.
- Flusher's partial-flush semantics (returns on first error) could be replaced with all-or-nothing pre-validation for cleaner failure handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)