### PR TITLE
Include exe-path fingerprint in VM log sentinels

### DIFF
--- a/internal/infra/process/expected_darwin.go
+++ b/internal/infra/process/expected_darwin.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package process
+
+// IsExpectedProcess on Darwin falls back to a plain liveness check.
+// macOS does not expose /proc, and reading another process's exe path
+// requires libproc/proc_pidpath via cgo — outside the scope of this
+// defensive cleanup helper. The tradeoff matches go-microvm's own
+// procutil.IsExpectedProcess on darwin: stale-cleanup on macOS is not
+// fully guarded against PID reuse.
+func IsExpectedProcess(pid int, _ string) bool {
+	if pid <= 0 {
+		return false
+	}
+	return IsAlive(pid)
+}

--- a/internal/infra/process/expected_linux.go
+++ b/internal/infra/process/expected_linux.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package process
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// IsExpectedProcess reports whether the process at pid is running the
+// expected binary. On Linux this reads /proc/<pid>/exe (a symlink to
+// the running binary) and compares against expectedBinary.
+//
+// When expectedBinary is an absolute path, the comparison is against
+// the full resolved exe path — the strong guarantee. When it is a
+// bare name, the comparison falls back to base-name equality; two
+// unrelated binaries with the same base name on the same host would
+// collide under the fallback, so callers should pass the absolute
+// path they got from os.Executable() when possible.
+//
+// The "(deleted)" suffix that the kernel appends when the underlying
+// binary has been unlinked post-exec is stripped, so a bbox still
+// running from an upgraded-away binary is correctly identified.
+//
+// Returns false when the process does not exist, is owned by another
+// user (permission denied on the symlink read), or runs a different
+// binary. A `false` result means "this PID is not the bbox we
+// remembered" — the caller should treat its sentinel as stale.
+func IsExpectedProcess(pid int, expectedBinary string) bool {
+	if pid <= 0 || expectedBinary == "" {
+		return false
+	}
+	exePath, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+	if err != nil {
+		return false
+	}
+	exePath = strings.TrimSuffix(exePath, " (deleted)")
+	if filepath.IsAbs(expectedBinary) {
+		return filepath.Clean(exePath) == filepath.Clean(expectedBinary)
+	}
+	return filepath.Base(exePath) == filepath.Base(expectedBinary)
+}

--- a/internal/infra/process/expected_linux_test.go
+++ b/internal/infra/process/expected_linux_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsExpectedProcess_SelfAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	assert.True(t, IsExpectedProcess(os.Getpid(), exe),
+		"IsExpectedProcess(self, self-exe) must return true")
+}
+
+func TestIsExpectedProcess_SelfBaseNameFallback(t *testing.T) {
+	t.Parallel()
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	// Base-name-only comparison path: if the stored binary is not
+	// absolute, we accept any process whose base name matches.
+	assert.True(t, IsExpectedProcess(os.Getpid(), filepath.Base(exe)),
+		"IsExpectedProcess with bare base name should match self")
+}
+
+func TestIsExpectedProcess_WrongBinary(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, IsExpectedProcess(os.Getpid(), "/nonexistent/not-bbox"),
+		"IsExpectedProcess with wrong absolute path must return false")
+}
+
+func TestIsExpectedProcess_NonExistentPID(t *testing.T) {
+	t.Parallel()
+
+	// PID 2147483647 is MAX_INT32 — extremely unlikely to be alive.
+	assert.False(t, IsExpectedProcess(2147483647, "/any/path"),
+		"IsExpectedProcess must return false for a non-existent PID")
+}
+
+func TestIsExpectedProcess_InvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, IsExpectedProcess(0, "/any/path"))
+	assert.False(t, IsExpectedProcess(-1, "/any/path"))
+	assert.False(t, IsExpectedProcess(os.Getpid(), ""))
+}

--- a/internal/infra/vm/cleanup.go
+++ b/internal/infra/vm/cleanup.go
@@ -5,6 +5,7 @@ package vm
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -18,9 +19,37 @@ import (
 // to identify ownership by a running bbox process.
 const LogSentinel = ".bbox-sentinel"
 
+// maxSentinelSize is a generous upper bound on the sentinel file
+// size. A well-formed sentinel is ~32 bytes (PID + newline + exe
+// path); 4 KiB is plenty and prevents a same-UID attacker from
+// forcing bbox to load a multi-GiB file into memory at startup by
+// planting a giant sentinel.
+const maxSentinelSize = 4096
+
+// parseSentinel decodes the sentinel file contents. The current format
+// is two lines: PID\nEXEPATH. The previous format was a single PID.
+// Both are accepted; a missing exe path means "caller should use a
+// plain liveness check for backward compatibility".
+func parseSentinel(data []byte) (pid int, exePath string, ok bool) {
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return 0, "", false
+	}
+	lines := strings.SplitN(content, "\n", 2)
+	p, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil || p <= 0 {
+		return 0, "", false
+	}
+	if len(lines) > 1 {
+		exePath = strings.TrimSpace(lines[1])
+	}
+	return p, exePath, true
+}
+
 // CleanupStaleLogs removes orphaned per-VM log directories from previous
 // crashes. It scans vmsDir for subdirectories with a sentinel file whose
-// owning process has died.
+// owning process has died or whose PID has been recycled onto a different
+// binary since the sentinel was written.
 func CleanupStaleLogs(vmsDir string, logger *slog.Logger) {
 	entries, err := os.ReadDir(vmsDir)
 	if err != nil {
@@ -42,38 +71,94 @@ func CleanupStaleLogs(vmsDir string, logger *slog.Logger) {
 		// Only remove directories that have our sentinel file to avoid
 		// deleting unrelated directories.
 		sentinelPath := filepath.Join(dirPath, LogSentinel)
-		data, err := os.ReadFile(sentinelPath)
+		data, err := readSentinelFile(sentinelPath)
 		if err != nil {
-			logger.Debug("skipping VM directory without sentinel", "path", dirPath)
+			if os.IsNotExist(err) {
+				logger.Debug("skipping VM directory without sentinel", "path", dirPath)
+			} else {
+				// Permission denied, oversize, or other unexpected I/O
+				// errors deserve visibility distinct from the "no
+				// sentinel at all" case — helps triage on shared hosts.
+				logger.Debug("skipping VM directory with unreadable sentinel",
+					"path", dirPath, "error", err)
+			}
 			continue
 		}
 
-		// If the sentinel contains a PID, check if that process is still alive.
-		// Skip cleanup for directories owned by a running process.
-		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-		if err != nil || pid <= 0 {
+		pid, exePath, ok := parseSentinel(data)
+		if !ok {
 			logger.Debug("skipping VM directory with invalid sentinel", "path", dirPath)
 			continue
 		}
 
-		if process.IsAlive(pid) {
+		// Prefer the fingerprint-aware check when the sentinel carries
+		// an exe path: it correctly distinguishes a recycled PID (now
+		// hosting an unrelated process) from a still-running bbox. Fall
+		// back to plain liveness for legacy single-line sentinels.
+		var ownerLive bool
+		var reason string
+		if exePath != "" {
+			ownerLive = process.IsExpectedProcess(pid, exePath)
+			reason = "fingerprint-mismatch-or-dead"
+		} else {
+			ownerLive = process.IsAlive(pid)
+			reason = "pid-dead"
+		}
+
+		if ownerLive {
 			logger.Debug("skipping VM log directory owned by running process",
 				"path", dirPath, "pid", pid)
 			continue
 		}
 
-		logger.Warn("removing stale VM log directory", "path", dirPath)
+		logger.Warn("removing stale VM log directory",
+			"path", dirPath, "pid", pid, "reason", reason)
 		if err := os.RemoveAll(dirPath); err != nil {
 			logger.Error("failed to remove stale VM log directory", "path", dirPath, "error", err)
 		}
 	}
 }
 
-// WriteSentinel writes a PID sentinel file into the given directory to mark
-// ownership by the current process. Returns an error if the write fails.
+// readSentinelFile reads a sentinel with a size cap. Returns an error
+// wrapping the underlying read error for permission-denied / I/O
+// failures, and a specific "too large" error when the file exceeds
+// maxSentinelSize (defensive cap against a planted giant sentinel).
+func readSentinelFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > maxSentinelSize {
+		return nil, fmt.Errorf("sentinel %s too large: %d bytes (limit %d)",
+			path, info.Size(), maxSentinelSize)
+	}
+	return io.ReadAll(io.LimitReader(f, maxSentinelSize))
+}
+
+// WriteSentinel writes a PID+exe-path sentinel file into the given
+// directory to mark ownership by the current process. The exe path
+// lets future CleanupStaleLogs invocations distinguish "bbox still
+// alive at pid X" from "pid X has been recycled onto some unrelated
+// process" — a kill -0 liveness check alone cannot tell those apart.
 func WriteSentinel(dir string) error {
 	sentinelPath := filepath.Join(dir, LogSentinel)
-	content := fmt.Sprintf("%d", os.Getpid())
+	// os.Executable returns the path to the currently running bbox.
+	// Failure is tolerated: we simply fall back to a PID-only sentinel
+	// and the cleanup path will use plain liveness. This matches the
+	// behavior of installations where /proc is unavailable.
+	exe, _ := os.Executable()
+	var content string
+	if exe != "" {
+		content = fmt.Sprintf("%d\n%s", os.Getpid(), exe)
+	} else {
+		content = fmt.Sprintf("%d", os.Getpid())
+	}
 	if err := os.WriteFile(sentinelPath, []byte(content), 0o600); err != nil {
 		return fmt.Errorf("writing log sentinel: %w", err)
 	}

--- a/internal/infra/vm/cleanup_test.go
+++ b/internal/infra/vm/cleanup_test.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -175,7 +177,17 @@ func TestWriteSentinel(t *testing.T) {
 
 	data, err := os.ReadFile(filepath.Join(dir, LogSentinel))
 	require.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%d", os.Getpid()), string(data))
+
+	// Sentinel format: `PID\nEXEPATH`. PID is on line 1.
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	assert.Equal(t, fmt.Sprintf("%d", os.Getpid()), lines[0])
+
+	// os.Executable is expected to succeed in the test environment, so
+	// the sentinel should carry an exe path fingerprint too.
+	require.Len(t, lines, 2, "sentinel should carry PID + exe path")
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	assert.Equal(t, exe, lines[1])
 }
 
 func TestWriteSentinel_FilePermissions(t *testing.T) {
@@ -203,7 +215,8 @@ func TestWriteSentinel_Overwrite(t *testing.T) {
 
 	data, err := os.ReadFile(filepath.Join(dir, LogSentinel))
 	require.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%d", os.Getpid()), string(data),
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	assert.Equal(t, fmt.Sprintf("%d", os.Getpid()), lines[0],
 		"sentinel should contain current PID after overwrite")
 }
 
@@ -212,4 +225,107 @@ func TestWriteSentinel_NonexistentDirectory(t *testing.T) {
 
 	err := WriteSentinel(filepath.Join(t.TempDir(), "nonexistent"))
 	assert.Error(t, err, "writing sentinel to nonexistent directory should fail")
+}
+
+func TestCleanupStaleLogs_FingerprintMismatchRemoved(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "linux" {
+		// /proc/<pid>/exe is Linux-only; on darwin IsExpectedProcess
+		// falls back to plain liveness and cannot detect PID reuse.
+		t.Skip("fingerprint check is Linux-only")
+	}
+
+	vmsDir := filepath.Join(t.TempDir(), "vms")
+	require.NoError(t, os.MkdirAll(vmsDir, 0o755))
+
+	// Simulate PID reuse: the sentinel claims the current PID was bbox
+	// with a fake exe path that /proc/self/exe will NOT match.
+	// IsExpectedProcess returns false → directory is treated as stale.
+	dir := filepath.Join(vmsDir, "recycled-pid")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	content := fmt.Sprintf("%d\n/nonexistent/fake-bbox-binary", os.Getpid())
+	require.NoError(t, os.WriteFile(filepath.Join(dir, LogSentinel), []byte(content), 0o600))
+
+	CleanupStaleLogs(vmsDir, testLogger())
+
+	_, err := os.Stat(dir)
+	assert.True(t, os.IsNotExist(err),
+		"directory whose sentinel names a different binary should be removed")
+}
+
+func TestCleanupStaleLogs_FingerprintMatchPreserved(t *testing.T) {
+	t.Parallel()
+
+	vmsDir := filepath.Join(t.TempDir(), "vms")
+	require.NoError(t, os.MkdirAll(vmsDir, 0o755))
+
+	// Sentinel claims the current PID running the real test binary —
+	// fingerprint matches (Linux) or legacy-liveness matches (darwin) —
+	// directory must be preserved.
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	dir := filepath.Join(vmsDir, "live-bbox")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	content := fmt.Sprintf("%d\n%s", os.Getpid(), exe)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, LogSentinel), []byte(content), 0o600))
+
+	CleanupStaleLogs(vmsDir, testLogger())
+
+	_, err = os.Stat(dir)
+	assert.NoError(t, err, "directory with matching fingerprint should remain")
+}
+
+func TestCleanupStaleLogs_OversizedSentinelSkipped(t *testing.T) {
+	t.Parallel()
+
+	vmsDir := filepath.Join(t.TempDir(), "vms")
+	require.NoError(t, os.MkdirAll(vmsDir, 0o755))
+
+	// Planted giant sentinel (8 KiB > 4 KiB cap). Cleanup must not
+	// read it into memory and must leave the dir alone — the file is
+	// suspicious and silently nuking would be worse than skipping.
+	dir := filepath.Join(vmsDir, "giant-sentinel")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	huge := make([]byte, 8192)
+	for i := range huge {
+		huge[i] = '1'
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, LogSentinel), huge, 0o600))
+
+	CleanupStaleLogs(vmsDir, testLogger())
+
+	_, err := os.Stat(dir)
+	assert.NoError(t, err, "directory with oversized sentinel should be left alone")
+}
+
+func TestCleanupStaleLogs_LegacyPIDOnlySentinelStillWorks(t *testing.T) {
+	t.Parallel()
+
+	vmsDir := filepath.Join(t.TempDir(), "vms")
+	require.NoError(t, os.MkdirAll(vmsDir, 0o755))
+
+	// Legacy v1 sentinel (just a PID, no exe path) written by an older
+	// bbox build. Cleanup must fall back to a plain liveness check.
+
+	// Live PID, legacy format — preserved.
+	liveDir := filepath.Join(vmsDir, "live-legacy")
+	require.NoError(t, os.MkdirAll(liveDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(liveDir, LogSentinel),
+		[]byte(fmt.Sprintf("%d", os.Getpid())), 0o600))
+
+	// Dead PID, legacy format — removed.
+	staleDir := filepath.Join(vmsDir, "stale-legacy")
+	require.NoError(t, os.MkdirAll(staleDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(staleDir, LogSentinel),
+		[]byte("2147483647"), 0o600))
+
+	CleanupStaleLogs(vmsDir, testLogger())
+
+	_, err := os.Stat(liveDir)
+	assert.NoError(t, err, "legacy sentinel with live PID should preserve directory")
+
+	_, err = os.Stat(staleDir)
+	assert.True(t, os.IsNotExist(err), "legacy sentinel with dead PID should remove directory")
 }


### PR DESCRIPTION
## Summary

Closes a MEDIUM correctness finding: `CleanupStaleLogs` used plain `kill -0` liveness to decide whether to remove a per-VM log directory. That check cannot distinguish "bbox still alive at PID X" from "PID X recycled to an unrelated process". Two failure modes:

- Crashed bbox whose PID is now held by some other process → log dir never cleaned up (cleanup assumes bbox is still alive).
- Fresh bbox whose PID was previously held by something → incorrectly skips cleanup of its own stale dir from a prior boot.

Neither is a privilege boundary, but both cause reliability/hygiene problems — the same class go-microvm v0.0.32 closed for `terminateStaleRunner` via `procutil.IsExpectedProcess`.

## Changes

- **Sentinel format extended** from `<pid>` to `<pid>\n<exe-path>`. `WriteSentinel` uses `os.Executable()` to record the absolute bbox binary path.
- **New helper** `process.IsExpectedProcess(pid, exe)`:
  - Linux: reads `/proc/<pid>/exe` symlink and compares (strips `" (deleted)"` suffix). Handles permission-denied and ENOENT as "not a match" → dir removed.
  - Darwin: falls back to plain liveness (no `/proc`; avoiding cgo). Documented as a known limitation, mirrors go-microvm's darwin behavior.
- **`CleanupStaleLogs`** branches on sentinel format: v2 (PID+exe) uses `IsExpectedProcess`, v1 (legacy PID-only) uses the old `IsAlive` fallback.
- **Backward compatible**: existing v1 sentinels on disk continue to work transparently; new writes produce v2.
- **Sentinel size cap (4 KiB)**: a same-UID attacker cannot force bbox to OOM at startup by planting a giant `.bbox-sentinel`. Files over the cap are skipped (not nuked — the content is suspicious, leave it alone).
- **Structured `reason` on the stale-removal warn log**: `"pid-dead"` vs `"fingerprint-mismatch-or-dead"` makes triage obvious.
- **Debug log distinguishes** "sentinel missing" from "sentinel unreadable" (permission-denied on shared hosts).

## Test plan

- [x] `task fmt && task lint && task test` — all green
- [x] `process.IsExpectedProcess` unit tests (Linux): self absolute-path, self base-name, wrong binary, non-existent PID, invalid inputs
- [x] `CleanupStaleLogs` tests: fingerprint match preserves, fingerprint mismatch removes (Linux-only skip), legacy PID-only still works, oversized sentinel left alone
- [x] Full e2e: `bbox claude-code --no-mcp --exec /bin/true` writes v2 sentinel (inspected), cleans up on next run

## Follow-ups (not this PR)

- Darwin could implement real fingerprinting via `golang.org/x/sys/unix.Sysctl("kern.proc.pathname.<pid>")` to close the PID-reuse gap on macOS. Currently degrade-gracefully.
- Pre-existing quirk: `BBOX_KEEP_VM_DATA=1` preserves debug data only until the next bbox run. Worth a separate discussion about scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)