### PR TITLE
Fix handling of read-only source file cloning

### DIFF
--- a/internal/infra/workspace/clone.go
+++ b/internal/infra/workspace/clone.go
@@ -37,7 +37,8 @@ func copyFile(src, dst string) error {
 	// Strip setuid/setgid/sticky — only preserve rwx permissions.
 	mode := info.Mode().Perm()
 
-	df, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	// Open writable and change permissions after copy to handle read-only src.
+	df, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("creating destination: %w", err)
 	}
@@ -48,7 +49,11 @@ func copyFile(src, dst string) error {
 	}
 
 	// Explicitly close and return any error (e.g., NFS write-back failure).
-	return df.Close()
+	if err := df.Close(); err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, mode)
 }
 
 // ValidateInBounds verifies that targetPath (after resolution) is within

--- a/internal/infra/workspace/clone_linux.go
+++ b/internal/infra/workspace/clone_linux.go
@@ -43,11 +43,16 @@ func (c *linuxCloner) tryFiclone(src, dst string) error {
 		return err
 	}
 
-	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	// Open writable and change permissions after clone to handle read-only src.
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = dstFile.Close() }()
 
-	return unix.IoctlFileClone(int(dstFile.Fd()), int(srcFile.Fd()))
+	if err := unix.IoctlFileClone(int(dstFile.Fd()), int(srcFile.Fd())); err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, srcInfo.Mode().Perm())
 }

--- a/internal/infra/workspace/snapshot.go
+++ b/internal/infra/workspace/snapshot.go
@@ -148,11 +148,11 @@ func (c *FSWorkspaceCloner) CreateSnapshot(ctx context.Context, workspacePath st
 	// Always wait for workers to finish before cleanup runs, even if walk failed.
 	waitErr := g.Wait()
 
-	if err != nil {
-		return nil, fmt.Errorf("walking workspace: %w", err)
-	}
 	if waitErr != nil {
 		return nil, fmt.Errorf("cloning files: %w", waitErr)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("walking workspace: %w", err)
 	}
 
 	// Write sentinel file with our PID to identify this as an active snapshot.


### PR DESCRIPTION
When invoking `bbox` in a working directory with read-only file(s), the operation will fail with a "context canceled" error message. These changes fix handling of such files by opening the destination file with write permissions and changing them to match the source file permissions after a successful copy operation.

Additionally, swap the error evaluation order in `CreateSnapshot` in order to show underlying I/O error messages.