### PR TITLE
Fix opencode settings filter to inject custom provider

### DIFF
--- a/internal/infra/agent/registry.go
+++ b/internal/infra/agent/registry.go
@@ -175,8 +175,8 @@ func builtinAgents() map[string]domainagent.Agent {
 					Format: "jsonc", Filter: &settings.FieldFilter{
 						// NOTE: "mcp" is excluded — the VM cannot reach host MCP servers.
 						// Only the toolhive-proxied sandbox-tools should be present.
-						AllowKeys: []string{"providers", "models", "agent", "tools", "plugin", "theme", "command", "instructions", "formatter", "shell", "permission"},
-						DenySubKeys: map[string][]string{"providers": {
+						AllowKeys: []string{"provider", "models", "agent", "tools", "plugin", "theme", "command", "instructions", "formatter", "shell", "permission"},
+						DenySubKeys: map[string][]string{"provider": {
 							"*.api_key", "*.apiKey", "*.secret", "*.token",
 							"*.password", "*.credentials", "*.accessToken",
 							"*.access_token", "*.client_secret",


### PR DESCRIPTION
The opencode.json section to customize providers is called `provider` not `providers`, see [1]. This fixes injection of provider config for Opencode agent.

[1] https://opencode.ai/docs/providers/#config