### PR TITLE
Fix: prevent recursive snapshot self-copy when cache dir falls within workspace

### DIFF
--- a/internal/infra/workspace/snapshot.go
+++ b/internal/infra/workspace/snapshot.go
@@ -111,6 +111,15 @@ func (c *FSWorkspaceCloner) CreateSnapshot(ctx context.Context, workspacePath st
 			return nil
 		}
 
+		// Skip the snapshot cache directory to prevent recursive self-copy
+		// when the snapshot base dir falls within the workspace tree.
+		if path == c.snapshotBaseDir || strings.HasPrefix(path, c.snapshotBaseDir+string(os.PathSeparator)) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
 		destPath := filepath.Join(tmpDir, relPath)
 
 		// Handle symlinks first (metadata-only, fast — stays synchronous).

--- a/internal/infra/workspace/snapshot.go
+++ b/internal/infra/workspace/snapshot.go
@@ -53,7 +53,7 @@ type FSWorkspaceCloner struct {
 func NewFSWorkspaceCloner(cloner FileCloner, snapshotBaseDir string, logger *slog.Logger) *FSWorkspaceCloner {
 	return &FSWorkspaceCloner{
 		cloner:          cloner,
-		snapshotBaseDir: snapshotBaseDir,
+		snapshotBaseDir: filepath.Clean(snapshotBaseDir),
 		logger:          logger,
 	}
 }

--- a/internal/infra/workspace/snapshot_test.go
+++ b/internal/infra/workspace/snapshot_test.go
@@ -296,6 +296,46 @@ func TestCleanupStaleSnapshots_NonExistentDir(t *testing.T) {
 	CleanupStaleSnapshots(filepath.Join(t.TempDir(), "does-not-exist"), logger)
 }
 
+func TestCreateSnapshot_SelfRecursionPrevention(t *testing.T) {
+	t.Parallel()
+
+	// Simulate the bug scenario: snapshot base dir lives INSIDE the workspace.
+	// When the workspace is the home directory (e.g. CWD=~/), the XDG cache
+	// dir ~/.cache/broodbox/snapshots/ falls within the workspace tree.
+	workspaceDir := t.TempDir()
+	snapshotBaseDir := filepath.Join(workspaceDir, ".cache", "broodbox", "snapshots")
+
+	// Create files in the workspace (including under the snapshot base dir
+	// to simulate prior cache content, e.g. firmware downloads).
+	require.NoError(t, os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(workspaceDir, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workspaceDir, "src", "lib.go"), []byte("package src"), 0o644))
+
+	// Pre-populate a file inside the snapshot cache (simulates firmware downloads).
+	require.NoError(t, os.MkdirAll(filepath.Join(snapshotBaseDir, "firmware", "v1.0"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(snapshotBaseDir, "firmware", "v1.0", "libkrunfw.so"), []byte("firmware"), 0o644))
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cloner := NewFSWorkspaceCloner(&fallbackCloner{}, snapshotBaseDir, logger)
+	matcher := &testMatcher{excluded: map[string]bool{}}
+
+	snap, err := cloner.CreateSnapshot(context.Background(), workspaceDir, matcher)
+	require.NoError(t, err)
+	defer func() { _ = snap.Cleanup() }()
+
+	// Regular files should be in the snapshot.
+	data, err := os.ReadFile(filepath.Join(snap.SnapshotPath, "main.go"))
+	require.NoError(t, err)
+	assert.Equal(t, "package main", string(data))
+
+	// The snapshot cache directory tree should NOT be inside the snapshot.
+	// (Parent dirs .cache/ and .cache/broodbox/ are created as empty stubs
+	// because the walker must enter them before reaching snapshots/ where
+	// the skip fires — that's harmless and doesn't cause recursion.)
+	_, err = os.Stat(filepath.Join(snap.SnapshotPath, ".cache", "broodbox", "snapshots"))
+	assert.True(t, os.IsNotExist(err), "snapshot cache directory should not be copied into the snapshot")
+}
+
 func TestPlatformCloner(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

When the workspace is the home directory (`~/`) or any ancestor of `~/.cache/broodbox/snapshots/`, the snapshot temp dir is created **inside** the workspace tree being walked.

`filepath.WalkDir` calls the callback for a directory **before** reading its entries. When the callback fires for the temp dir, `os.MkdirAll(destPath, ...)` creates a nested copy of the snapshot dir inside itself. `WalkDir` then calls `readDir` on the source directory, discovers the freshly-planted nested directory, and recurses — creating an infinite loop.

Each iteration adds another segment to the path until the OS's `ENAMETOOLONG` limit is hit:

```
Error: creating workspace snapshot: cloning files: creating destination:
open .../.cache/broodbox/snapshots/.sandbox-snapshot-123/
     broodbox/snapshots/.sandbox-snapshot-123/
     broodbox/snapshots/.sandbox-snapshot-123/
     ...(repeating)...
     /libkrunfw.so.5: file name too long
```

## Fix

Skip the entire `snapshotBaseDir` tree in the `WalkDir` callback. When the path equals or is under the snapshot cache directory, return `filepath.SkipDir`. This prevents both the current tmpDir and any stale snapshots from being walked.

## Test

Added `TestCreateSnapshot_SelfRecursionPrevention` that places the snapshot cache inside the workspace (simulating the CWD=~/ scenario), pre-populates cache-like files, and verifies the snapshot completes without recursion and that the cache directory is not copied into the snapshot.


edit: signed off by me, overviewed, pr written and opened via AI, looked legit (also a real issue i ran into)