### PR TITLE
Add jq to base guest image

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -19,6 +19,7 @@ RUN apk add --no-cache \
     sed \
     gawk \
     curl \
+    jq \
     openssh-client \
     make \
     gcc \


### PR DESCRIPTION
## Summary
- Add `jq` to the apk install list in `images/base/Dockerfile` so it's available to all guest images that derive from base.

## Test plan
- [ ] `task image-base` builds successfully
- [ ] `jq --version` works inside a guest VM started from the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)