### PR TITLE
Let Renovate manage pinned Dockerfile tool versions

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -45,12 +45,14 @@ RUN printf '%s\n' \
 RUN mkdir -p /usr/local/bin
 
 # Install go-task from GitHub releases (not packaged in Wolfi).
+# renovate: datasource=github-releases depName=go-task/task
 ARG TASK_VERSION=v3.48.0
 RUN ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
     curl -fsSL "https://github.com/go-task/task/releases/download/${TASK_VERSION}/task_linux_${ARCH}.tar.gz" | \
     tar -xz -C /usr/local/bin task
 
 # Install golangci-lint from GitHub releases (not packaged in Wolfi).
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 ARG GOLANGCI_LINT_VERSION=v2.10.1
 RUN ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
     VER="${GOLANGCI_LINT_VERSION#v}" && \

--- a/images/hermes/Dockerfile
+++ b/images/hermes/Dockerfile
@@ -10,6 +10,7 @@ FROM ${BASE_IMAGE}
 
 # Pin to a calendar-versioned Hermes Agent tag. Bump deliberately; releases
 # are roughly weekly. Override with --build-arg HERMES_VERSION=... for dev.
+# renovate: datasource=github-tags depName=NousResearch/hermes-agent
 ARG HERMES_VERSION=v2026.4.16
 
 LABEL org.opencontainers.image.source="https://github.com/NousResearch/hermes-agent" \

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "customManagers:dockerfileVersions"
   ]
 }


### PR DESCRIPTION
## What

Brings the three hardcoded tool versions in our guest-image Dockerfiles under Renovate management. Today these are pinned `ARG`s consumed by `curl`/`git clone`, so Renovate (bare `config:recommended`) can't see them — they only move when someone notices.

| Var | Pinned | Latest | depName / datasource |
|---|---|---|---|
| `TASK_VERSION` | `v3.48.0` | `v3.51.1` | `go-task/task` / github-releases |
| `GOLANGCI_LINT_VERSION` | `v2.10.1` | `v2.12.2` | `golangci/golangci-lint` / github-releases |
| `HERMES_VERSION` | `v2026.4.16` | `v2026.5.29` | `NousResearch/hermes-agent` / github-tags |

## How

- Enable the official **`customManagers:dockerfileVersions`** preset in `renovate.json` (ships the maintained regex for `_VERSION` ARG/ENV vars; no hand-rolled regex).
- Add a `# renovate:` annotation directly above each `ARG`. The preset requires the comment immediately above the line and the var name to end in `_VERSION` — both satisfied.
- Hermes uses `github-tags` rather than `github-releases` because the Dockerfile `git clone --branch`es a tag.

Verified the preset regex against [renovate source](https://github.com/renovatebot/renovate/blob/main/lib/config/presets/internal/custom-managers.preset.ts) (accepts unquoted values like ours), confirmed each `depName`/datasource resolves against the live repos, and ran `renovate-config-validator` (passed).

## Expected effect

Next Renovate run should open three update PRs for the versions above.

## Out of scope (intentionally floating)

`wolfi-base:latest`, `claude.ai/install.sh`, the `releases/latest/download` URLs (codex, opencode), `@google/gemini-cli`, and `goimports@latest` remain unpinned — consistent with the `:latest`-only, rebuilt-weekly image model. Digest/version pinning those is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)