### PR TITLE
Add bbox run-image ephemeral one-shot command

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ bbox claude-code -- --help
 
 # List available agents
 bbox list
+
+# Run an arbitrary OCI image as an ephemeral one-shot (no persistence, no config)
+bbox run-image ghcr.io/jbarslox/aider-bbox:latest -- aider
+
+# Ephemeral run with restricted egress and a single forwarded env var
+bbox run-image ubuntu:24.04 \
+  --env OPENAI_API_KEY \
+  --egress-profile standard \
+  --allow-host api.openai.com:443 \
+  -- python -m http.server
 ```
 
 ### Workspace modes
@@ -298,6 +308,19 @@ agents:
     env_forward:
       - MY_API_KEY
       - MY_AGENT_*
+```
+
+### Bring-your-own image: `run-image`
+
+For a one-off image you don't want to declare in config, use `run-image`. It
+builds an in-memory agent from CLI flags with safer-than-custom defaults
+(credential persistence off, host settings import off, env forwarding empty,
+git token / SSH agent off, MCP off, egress permissive) and runs it through the
+same sandbox path. See [docs/run-image.md](docs/run-image.md) for the minimum
+image contract and the full flag set.
+
+```bash
+bbox run-image ghcr.io/jbarslox/aider-bbox:latest -- aider
 ```
 
 ## How It Works

--- a/cmd/bbox/main.go
+++ b/cmd/bbox/main.go
@@ -233,6 +233,7 @@ Example:
 	cmd.AddCommand(authCmd())
 	cmd.AddCommand(configCmd())
 	cmd.AddCommand(cacheCmd())
+	cmd.AddCommand(runImageCmd())
 
 	return cmd
 }
@@ -440,6 +441,14 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		}
 	}
 
+	// Validate MCP flags up front (shared with run-image). runSandbox re-checks
+	// these as defence-in-depth.
+	if flags.mcpAuthzProfile != "" || flags.mcpSessionTTL != 0 {
+		if err := validateMCPFlags(flags.mcpAuthzProfile, flags.mcpSessionTTL); err != nil {
+			return err
+		}
+	}
+
 	// Resolve workspace early so we can derive a deterministic VM name.
 	earlyWs := flags.workspace
 	if earlyWs == "" {
@@ -625,21 +634,80 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		return fmt.Errorf("config network.%w", egressErr)
 	}
 
+	return runSandbox(ctx, sandboxRunInput{
+		agentName:         agentName,
+		flags:             flags,
+		registry:          registry,
+		cfg:               cfg,
+		ws:                ws,
+		snapDir:           snapDir,
+		vmName:            vmName,
+		sessionID:         sessionID,
+		logPath:           logPath,
+		logFile:           logFile,
+		logger:            logger,
+		observer:          observer,
+		timingObs:         timingObs,
+		tracerProvider:    tracerProvider,
+		terminal:          terminal,
+		directMode:        directMode,
+		interactiveReview: interactiveReview,
+		snapshotMatcher:   snapshotMatcher,
+		diffMatcher:       diffMatcher,
+		configEgressHosts: configEgressHosts,
+		parsedPorts:       parsedPorts,
+	})
+}
+
+// sandboxRunInput bundles the resolved state that run() and runRunImage()
+// share with the post-resolution run tail (runSandbox). Keeping it in a
+// struct avoids a 20-parameter signature as the shared tail grew.
+type sandboxRunInput struct {
+	agentName         string
+	flags             runFlags
+	registry          *infraagent.Registry
+	cfg               *domainconfig.Config
+	ws                string
+	snapDir           string
+	vmName            string
+	sessionID         string
+	logPath           string
+	logFile           *os.File
+	logger            *slog.Logger
+	observer          progress.Observer
+	timingObs         *infraprogress.TimingObserver
+	tracerProvider    *sdktrace.TracerProvider
+	terminal          *infraterminal.OSTerminal
+	directMode        bool
+	interactiveReview bool
+	snapshotMatcher   snapshot.Matcher
+	diffMatcher       snapshot.Matcher
+	configEgressHosts []egress.Host
+	parsedPorts       []domvm.PortForward
+}
+
+// runSandbox is the shared post-resolution run tail: it wires the VM runner,
+// MCP proxy, snapshot isolation, credentials and settings from the resolved
+// registry/config, then drives the SandboxRunner through Prepare → Attach →
+// Stop → review/flush. Both run() (built-in/custom agents from config) and
+// runRunImage() (ephemeral in-memory agent built from CLI flags) reach the
+// same execution path through this function.
+func runSandbox(ctx context.Context, in sandboxRunInput) error {
 	// Build SandboxConfig from the loaded config.
 	sandboxCfg := &sandbox.SandboxConfig{
-		Defaults:         cfg.Defaults,
-		AgentOverrides:   cfg.Agents,
-		ExtraEgressHosts: configEgressHosts,
-		Image:            cfg.Image,
-		MCP:              cfg.MCP,
-		SettingsImport:   cfg.SettingsImport,
+		Defaults:         in.cfg.Defaults,
+		AgentOverrides:   in.cfg.Agents,
+		ExtraEgressHosts: in.configEgressHosts,
+		Image:            in.cfg.Image,
+		MCP:              in.cfg.MCP,
+		SettingsImport:   in.cfg.SettingsImport,
 	}
 
 	firmwareDownloadEnabled := true
-	if cfg.Runtime.FirmwareDownload != nil {
-		firmwareDownloadEnabled = *cfg.Runtime.FirmwareDownload
+	if in.cfg.Runtime.FirmwareDownload != nil {
+		firmwareDownloadEnabled = *in.cfg.Runtime.FirmwareDownload
 	}
-	if flags.noFirmwareDL {
+	if in.flags.noFirmwareDL {
 		firmwareDownloadEnabled = false
 	}
 
@@ -657,18 +725,18 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		CacheDir:        firmwareCachePath,
 		Version:         infraruntime.Version,
 		DownloadEnabled: firmwareDownloadEnabled,
-		Logger:          logger,
+		Logger:          in.logger,
 	})
 	if fwErr != nil {
 		return fmt.Errorf("resolving firmware: %w", fwErr)
 	}
-	logger.Debug("resolved firmware",
+	in.logger.Debug("resolved firmware",
 		"source", firmwareRes.Source,
 		"dir", firmwareRes.Dir,
 		"version", firmwareRes.Version,
 		"url", firmwareRes.URL,
 	)
-	dataDir, dataErr := infravm.VMDataDir(vmName)
+	dataDir, dataErr := infravm.VMDataDir(in.vmName)
 	if dataErr != nil {
 		return fmt.Errorf("resolving VM data directory: %w", dataErr)
 	}
@@ -692,11 +760,11 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 			infravm.WithRuntimeSource(infraruntime.RuntimeSource()),
 			infravm.WithCacheDir(cacheDir),
 		)
-		logger.Info("using embedded go-microvm runtime", "version", infraruntime.Version)
+		in.logger.Info("using embedded go-microvm runtime", "version", infraruntime.Version)
 	}
 
 	// Wire external OCI image cache (unless --no-image-cache is set).
-	if !flags.noImageCache {
+	if !in.flags.noImageCache {
 		imgCacheDir, imgCacheErr := imageCacheDir()
 		if imgCacheErr != nil {
 			return fmt.Errorf("resolving image cache directory: %w", imgCacheErr)
@@ -706,29 +774,29 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		// Best-effort stale cache eviction (entries older than 7 days).
 		cache := image.NewCache(imgCacheDir)
 		if removed, evictErr := cache.Evict(7 * 24 * time.Hour); evictErr != nil {
-			logger.Warn("failed to evict stale image cache entries", "error", evictErr)
+			in.logger.Warn("failed to evict stale image cache entries", "error", evictErr)
 		} else if removed > 0 {
-			logger.Info("evicted stale image cache entries", "count", removed)
+			in.logger.Info("evicted stale image cache entries", "count", removed)
 		}
 	}
 
 	// Resolve credential persistence setting.
-	saveCredentials := cfg.Auth.SaveCredentialsEnabled() && !flags.noSaveCredentials
+	saveCredentials := in.cfg.Auth.SaveCredentialsEnabled() && !in.flags.noSaveCredentials
 
 	// Resolve host credential seeding: opt-in via flag or config.
-	seedCreds := flags.seedCredentials || cfg.Auth.SeedHostCredentialsEnabled()
+	seedCreds := in.flags.seedCredentials || in.cfg.Auth.SeedHostCredentialsEnabled()
 
 	var credentialStore credential.Store
 	if saveCredentials {
 		credStateDir := filepath.Join(xdg.ConfigHome, "broodbox", "agent-state")
-		fsStore := infracredential.NewFSStore(credStateDir, logger)
+		fsStore := infracredential.NewFSStore(credStateDir, in.logger)
 		credentialStore = fsStore
 
 		if seedCreds {
-			if entry, lookupErr := registry.Get(agentName); lookupErr == nil && entry.Plugin != nil {
+			if entry, lookupErr := in.registry.Get(in.agentName); lookupErr == nil && entry.Plugin != nil {
 				if seeder := entry.Plugin.Seeder(); seeder != nil {
 					if err := seeder.Seed(fsStore); err != nil {
-						logger.Warn("credential seeding failed", "agent", agentName, "error", err)
+						in.logger.Warn("credential seeding failed", "agent", in.agentName, "error", err)
 					}
 				}
 			}
@@ -741,11 +809,11 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 
 	// Wire settings injector (enabled by default, --no-settings to disable).
 	var settingsInjector *infrasettings.FSInjector
-	settingsEnabled := cfg.SettingsImport.IsEnabled() && !flags.noSettings
+	settingsEnabled := in.cfg.SettingsImport.IsEnabled() && !in.flags.noSettings
 	if settingsEnabled {
-		settingsInjector = infrasettings.NewFSInjector(logger)
+		settingsInjector = infrasettings.NewFSInjector(in.logger)
 		vmRunnerOpts = append(vmRunnerOpts, infravm.WithSettingsInjector(settingsInjector))
-	} else if flags.noSettings {
+	} else if in.flags.noSettings {
 		// Ensure sandbox config reflects disabled state for the application layer.
 		disabled := false
 		sandboxCfg.SettingsImport.Enabled = &disabled
@@ -753,61 +821,64 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 
 	// Wire dependencies.
 	deps := sandbox.SandboxDeps{
-		Registry:         registry,
-		VMRunner:         infravm.NewMicroVMRunner(logger, vmRunnerOpts...),
-		SessionRunner:    infrassh.NewInteractiveSession(logger),
+		Registry:         in.registry,
+		VMRunner:         infravm.NewMicroVMRunner(in.logger, vmRunnerOpts...),
+		SessionRunner:    infrassh.NewInteractiveSession(in.logger),
 		Config:           sandboxCfg,
 		EnvProvider:      agent.NewOSEnvProvider(os.Environ),
-		Logger:           logger,
-		Observer:         observer,
+		Logger:           in.logger,
+		Observer:         in.observer,
 		CredentialStore:  credentialStore,
 		SettingsInjector: settingsInjector,
 	}
 
-	// Validate MCP authz profile flag early (before wiring).
-	if flags.mcpAuthzProfile != "" && !domainconfig.IsValidMCPAuthzProfile(flags.mcpAuthzProfile) {
+	// Validate MCP authz profile flag early (before wiring). This is a
+	// defence-in-depth re-check: the run() and runRunImage front-ends already
+	// validate via validateMCPFlags. For run() it is the primary guard since
+	// the front-end only checks when a flag is set; runSandbox always re-checks.
+	if in.flags.mcpAuthzProfile != "" && !domainconfig.IsValidMCPAuthzProfile(in.flags.mcpAuthzProfile) {
 		return fmt.Errorf("invalid --mcp-authz-profile %q: valid values are %v",
-			flags.mcpAuthzProfile, domainconfig.ValidMCPAuthzProfiles())
+			in.flags.mcpAuthzProfile, domainconfig.ValidMCPAuthzProfiles())
 	}
-	if flags.mcpSessionTTL < 0 {
-		return fmt.Errorf("--mcp-session-ttl must be non-negative, got %s", flags.mcpSessionTTL)
+	if in.flags.mcpSessionTTL < 0 {
+		return fmt.Errorf("--mcp-session-ttl must be non-negative, got %s", in.flags.mcpSessionTTL)
 	}
 
 	// Wire MCP proxy (enabled by default, --no-mcp to disable).
-	mcpEnabled := !flags.noMCP
-	if mcpEnabled && cfg != nil && cfg.MCP.Enabled != nil && !*cfg.MCP.Enabled {
+	mcpEnabled := !in.flags.noMCP
+	if mcpEnabled && in.cfg != nil && in.cfg.MCP.Enabled != nil && !*in.cfg.MCP.Enabled {
 		mcpEnabled = false
 	}
 	if mcpEnabled {
-		mcpGroup := flags.mcpGroup
-		mcpPort := flags.mcpPort
-		if cfg != nil {
-			if mcpGroup == "default" && cfg.MCP.Group != "" {
-				mcpGroup = cfg.MCP.Group
+		mcpGroup := in.flags.mcpGroup
+		mcpPort := in.flags.mcpPort
+		if in.cfg != nil {
+			if mcpGroup == "default" && in.cfg.MCP.Group != "" {
+				mcpGroup = in.cfg.MCP.Group
 			}
-			if mcpPort == 4483 && cfg.MCP.Port != 0 {
-				mcpPort = cfg.MCP.Port
+			if mcpPort == 4483 && in.cfg.MCP.Port != 0 {
+				mcpPort = in.cfg.MCP.Port
 			}
 		}
 
 		// Resolve MCP file config: CLI --mcp-config flag overrides config file.
 		var mcpFileConfig *domainconfig.MCPFileConfig
-		if flags.mcpConfig != "" {
+		if in.flags.mcpConfig != "" {
 			var loadErr error
-			mcpFileConfig, loadErr = inframcp.LoadMCPFileConfig(flags.mcpConfig)
+			mcpFileConfig, loadErr = inframcp.LoadMCPFileConfig(in.flags.mcpConfig)
 			if loadErr != nil {
 				return loadErr
 			}
-		} else if cfg != nil && cfg.MCP.Config != nil {
-			mcpFileConfig = cfg.MCP.Config
+		} else if in.cfg != nil && in.cfg.MCP.Config != nil {
+			mcpFileConfig = in.cfg.MCP.Config
 		}
 
 		// Resolve MCP authz config: CLI flag overrides config file.
 		var authzCfg *domainconfig.MCPAuthzConfig
-		if flags.mcpAuthzProfile != "" {
-			authzCfg = &domainconfig.MCPAuthzConfig{Profile: flags.mcpAuthzProfile}
-		} else if cfg != nil && cfg.MCP.Authz != nil {
-			authzCfg = cfg.MCP.Authz
+		if in.flags.mcpAuthzProfile != "" {
+			authzCfg = &domainconfig.MCPAuthzConfig{Profile: in.flags.mcpAuthzProfile}
+		} else if in.cfg != nil && in.cfg.MCP.Authz != nil {
+			authzCfg = in.cfg.MCP.Authz
 		}
 
 		// Implicit custom profile: if config has policies but no explicit
@@ -819,8 +890,8 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 
 		// Merge per-agent authz override (tighten-only) before constructing
 		// the VMCPProvider singleton.
-		if cfg != nil {
-			if ao, ok := cfg.Agents[agentName]; ok && ao.MCP != nil && ao.MCP.Authz != nil {
+		if in.cfg != nil {
+			if ao, ok := in.cfg.Agents[in.agentName]; ok && ao.MCP != nil && ao.MCP.Authz != nil {
 				authzCfg = domainconfig.MergeMCPAuthzConfig(authzCfg, ao.MCP.Authz)
 			}
 		}
@@ -830,18 +901,18 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		// CLI flag, global config, inferred custom policies, or per-agent
 		// override. Built-ins keep full-access. This is subordinate to every
 		// explicit source above, so an operator can still widen or tighten it.
-		authzCfg = applyCustomAgentAuthzDefault(authzCfg, isCustomAgent(registry, agentName))
+		authzCfg = applyCustomAgentAuthzDefault(authzCfg, isCustomAgent(in.registry, in.agentName))
 
 		// Resolve session TTL: flag (non-zero) > config > default (12h).
-		sessionTTL := flags.mcpSessionTTL
-		if sessionTTL == 0 && cfg != nil {
-			sessionTTL = cfg.MCP.ResolvedSessionTTL()
+		sessionTTL := in.flags.mcpSessionTTL
+		if sessionTTL == 0 && in.cfg != nil {
+			sessionTTL = in.cfg.MCP.ResolvedSessionTTL()
 		}
 		if sessionTTL == 0 {
 			sessionTTL = domainconfig.DefaultMCPSessionTTL
 		}
 
-		mcpProvider := inframcp.NewVMCPProvider(mcpGroup, mcpPort, mcpFileConfig, authzCfg, sessionTTL, logger, logFile)
+		mcpProvider := inframcp.NewVMCPProvider(mcpGroup, mcpPort, mcpFileConfig, authzCfg, sessionTTL, in.logger, in.logFile)
 		deps.MCPProvider = mcpProvider
 		defer func() { _ = mcpProvider.Close() }()
 		// Ensure sandbox config reflects MCP enabled state for the application layer.
@@ -853,9 +924,9 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		sandboxCfg.MCP.Authz = authzCfg
 	}
 
-	// Resolve git config from config + CLI flags.
-	gitTokenEnabled := cfg.Git.GitTokenEnabled() && !flags.noGitToken
-	sshAgentEnabled := cfg.Git.SSHAgentEnabled() && !flags.noGitSSHAgent
+	// Resolve git config from config + CLI in.flags.
+	gitTokenEnabled := in.cfg.Git.GitTokenEnabled() && !in.flags.noGitToken
+	sshAgentEnabled := in.cfg.Git.SSHAgentEnabled() && !in.flags.noGitSSHAgent
 
 	// Wire git identity provider (unconditional — used for both review and no-review modes).
 	deps.GitIdentityProvider = infragit.NewHostIdentityProvider("")
@@ -866,33 +937,33 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 	// and the snapshot post-processors (git config sanitizer, worktree
 	// reconstruction) are deliberately skipped; they operate on the
 	// snapshot directory that does not exist in direct mode.
-	if !directMode {
+	if !in.directMode {
 		deps.WorkspaceCloner = infraws.NewFSWorkspaceCloner(
-			infraws.NewPlatformCloner(), snapDir, logger,
+			infraws.NewPlatformCloner(), in.snapDir, in.logger,
 		)
-		if interactiveReview {
+		if in.interactiveReview {
 			deps.Reviewer = review.NewInteractiveReviewer(os.Stdin, os.Stdout)
 		} else {
-			deps.Reviewer = review.NewAutoAcceptReviewer(logger, os.Stderr)
+			deps.Reviewer = review.NewAutoAcceptReviewer(in.logger, os.Stderr)
 		}
 		deps.Flusher = review.NewFSFlusher()
 		deps.Differ = diff.NewFSDiffer()
 
 		// Wire snapshot post-processors (worktree reconstruction, then git config sanitizer).
 		deps.SnapshotPostProcessors = []workspace.SnapshotPostProcessor{
-			infragit.NewWorktreeProcessor(logger),
-			infragit.NewConfigSanitizer(logger),
+			infragit.NewWorktreeProcessor(in.logger),
+			infragit.NewConfigSanitizer(in.logger),
 		}
 	}
 
-	// Validate and parse egress flags.
-	if flags.egressProfile != "" && !egress.ProfileName(flags.egressProfile).IsValid() {
+	// Validate and parse egress in.flags.
+	if in.flags.egressProfile != "" && !egress.ProfileName(in.flags.egressProfile).IsValid() {
 		return fmt.Errorf("invalid --egress-profile %q: valid values are %v",
-			flags.egressProfile, egress.ValidProfiles())
+			in.flags.egressProfile, egress.ValidProfiles())
 	}
 
 	var parsedAllowHosts []egress.Host
-	for _, h := range flags.allowHosts {
+	for _, h := range in.flags.allowHosts {
 		parsed, parseErr := egress.ParseHostFlag(h)
 		if parseErr != nil {
 			return fmt.Errorf("--allow-host %q: %w", h, parseErr)
@@ -900,21 +971,21 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 		parsedAllowHosts = append(parsedAllowHosts, parsed)
 	}
 
-	if flags.egressProfile != "" {
-		logger.Info("egress profile override", "profile", flags.egressProfile)
+	if in.flags.egressProfile != "" {
+		in.logger.Info("egress profile override", "profile", in.flags.egressProfile)
 	}
 
 	runner := sandbox.NewSandboxRunner(deps)
 
 	var commandOverride []string
-	if flags.exec != "" {
-		commandOverride = []string{flags.exec}
+	if in.flags.exec != "" {
+		commandOverride = []string{in.flags.exec}
 	}
 
 	// Parse --memory flag (human-readable string → MiB).
 	var memoryMiB uint32
-	if flags.memory != "" {
-		parsed, parseErr := bytesize.ParseByteSize(flags.memory)
+	if in.flags.memory != "" {
+		parsed, parseErr := bytesize.ParseByteSize(in.flags.memory)
 		if parseErr != nil {
 			return fmt.Errorf("--memory: %w", parseErr)
 		}
@@ -923,8 +994,8 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 
 	// Parse --tmp-size flag (human-readable string → MiB).
 	var tmpSizeMiB uint32
-	if flags.tmpSize != "" {
-		parsed, parseErr := bytesize.ParseByteSize(flags.tmpSize)
+	if in.flags.tmpSize != "" {
+		parsed, parseErr := bytesize.ParseByteSize(in.flags.tmpSize)
 		if parseErr != nil {
 			return fmt.Errorf("--tmp-size: %w", parseErr)
 		}
@@ -934,58 +1005,58 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 	// Enable libkrun trace logging when --debug is set so vm.log
 	// captures hypervisor-level diagnostics.
 	var logLevel uint32
-	if flags.debug {
+	if in.flags.debug {
 		logLevel = 5 // trace
 	}
 
 	opts := sandbox.RunOpts{
-		CPUs:            flags.cpus,
+		CPUs:            in.flags.cpus,
 		Memory:          memoryMiB,
 		TmpSizeMiB:      tmpSizeMiB,
-		Workspace:       ws,
-		SSHPort:         flags.sshPort,
-		ExtraPorts:      parsedPorts,
-		ImageOverride:   flags.image,
-		EgressProfile:   flags.egressProfile,
+		Workspace:       in.ws,
+		SSHPort:         in.flags.sshPort,
+		ExtraPorts:      in.parsedPorts,
+		ImageOverride:   in.flags.image,
+		EgressProfile:   in.flags.egressProfile,
 		AllowHosts:      parsedAllowHosts,
 		GitTokenEnabled: gitTokenEnabled,
 		SSHAgentForward: sshAgentEnabled,
 		SSHAuthSock:     os.Getenv("SSH_AUTH_SOCK"),
-		SessionID:       sessionID,
+		SessionID:       in.sessionID,
 		CommandOverride: commandOverride,
 		LogLevel:        logLevel,
-		CommandArgs:     flags.commandArgs,
-		EnvForwardExtra: flags.envForward,
-		PullPolicy:      flags.pull,
+		CommandArgs:     in.flags.commandArgs,
+		EnvForwardExtra: in.flags.envForward,
+		PullPolicy:      in.flags.pull,
 		Snapshot: sandbox.SnapshotOpts{
-			Enabled:         !directMode,
-			SnapshotMatcher: snapshotMatcher,
-			DiffMatcher:     diffMatcher,
+			Enabled:         !in.directMode,
+			SnapshotMatcher: in.snapshotMatcher,
+			DiffMatcher:     in.diffMatcher,
 		},
 	}
 
-	sb, err := runner.Prepare(ctx, agentName, opts)
+	sb, err := runner.Prepare(ctx, in.agentName, opts)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if sb.Snapshot != nil {
-			observer.Start(progress.PhaseCleaning, "Cleaning up...")
+			in.observer.Start(progress.PhaseCleaning, "Cleaning up...")
 			if cleanErr := sb.Cleanup(); cleanErr != nil {
-				observer.Fail("Failed to clean up snapshot")
-				logger.Error("failed to clean up snapshot", "error", cleanErr)
+				in.observer.Fail("Failed to clean up snapshot")
+				in.logger.Error("failed to clean up snapshot", "error", cleanErr)
 			} else {
-				observer.Complete("Cleaned up snapshot")
+				in.observer.Complete("Cleaned up snapshot")
 			}
 		}
 	}()
 
-	termErr := runner.Attach(ctx, sb, terminal)
+	termErr := runner.Attach(ctx, sb, in.terminal)
 
 	runner.ExtractCredentials(sb)
 
 	if stopErr := runner.Stop(sb); stopErr != nil {
-		logger.Error("failed to stop VM", "error", stopErr)
+		in.logger.Error("failed to stop VM", "error", stopErr)
 	}
 
 	var reviewErr error
@@ -1003,13 +1074,13 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 					maybePrintSubmoduleHint(os.Stderr, result.Accepted)
 				}
 			} else {
-				observer.Warn("No changes accepted")
+				in.observer.Warn("No changes accepted")
 			}
 		} else {
-			observer.Warn("No workspace changes detected")
+			in.observer.Warn("No workspace changes detected")
 		}
 		if reviewErr != nil {
-			logger.Error("review/flush failed", "error", reviewErr)
+			in.logger.Error("review/flush failed", "error", reviewErr)
 		}
 	}
 
@@ -1031,13 +1102,13 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 			// the timing summary now.
 			if sb.Snapshot != nil {
 				if cleanErr := sb.Cleanup(); cleanErr != nil {
-					logger.Error("failed to clean up snapshot", "error", cleanErr)
+					in.logger.Error("failed to clean up snapshot", "error", cleanErr)
 				}
 			}
-			if timingObs != nil {
-				timingObs.Summary(os.Stderr)
+			if in.timingObs != nil {
+				in.timingObs.Summary(os.Stderr)
 			}
-			infratracing.Shutdown(context.Background(), tracerProvider)
+			infratracing.Shutdown(context.Background(), in.tracerProvider)
 			os.Exit(exitErr.Code)
 		}
 		// Print available agents on not-found errors.
@@ -1048,8 +1119,8 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 			// custom agents), point at `bbox agents doctor` instead of the
 			// generic "Available agents" list — the user did declare it, it
 			// just failed validation, so "you typo'd" is the wrong message.
-			if cfg != nil {
-				if _, declared := cfg.Agents[notFound.Name]; declared {
+			if in.cfg != nil {
+				if _, declared := in.cfg.Agents[notFound.Name]; declared {
 					_, _ = fmt.Fprintf(os.Stderr,
 						"\nAgent %q is declared in config but was not registered (it failed validation).\n"+
 							"Run 'bbox agents doctor %s' for details.\n",
@@ -1058,7 +1129,7 @@ func run(parentCtx context.Context, agentName string, flags runFlags) error {
 				}
 			}
 			_, _ = fmt.Fprintf(os.Stderr, "\nAvailable agents:\n")
-			for _, e := range registry.List() {
+			for _, e := range in.registry.List() {
 				_, _ = fmt.Fprintf(os.Stderr, "  %-15s %s\n", e.Agent.Name, e.Agent.Image)
 			}
 		}

--- a/cmd/bbox/run_image.go
+++ b/cmd/bbox/run_image.go
@@ -1,0 +1,672 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	infraagent "github.com/stacklok/brood-box/internal/infra/agent"
+	"github.com/stacklok/brood-box/internal/infra/exclude"
+	infraprogress "github.com/stacklok/brood-box/internal/infra/progress"
+	infraterminal "github.com/stacklok/brood-box/internal/infra/terminal"
+	infratracing "github.com/stacklok/brood-box/internal/infra/tracing"
+	infravm "github.com/stacklok/brood-box/internal/infra/vm"
+	infraws "github.com/stacklok/brood-box/internal/infra/workspace"
+	"github.com/stacklok/brood-box/pkg/domain/agent"
+	"github.com/stacklok/brood-box/pkg/domain/bytesize"
+	domainconfig "github.com/stacklok/brood-box/pkg/domain/config"
+	"github.com/stacklok/brood-box/pkg/domain/egress"
+	"github.com/stacklok/brood-box/pkg/domain/snapshot"
+	"github.com/stacklok/brood-box/pkg/sandbox"
+)
+
+// runImageFlags holds the flag values for `bbox run-image`. It is a subset of
+// runFlags tailored to the ephemeral one-shot UX: MCP defaults to OFF (opt-in
+// via --mcp), env forwarding defaults to EMPTY, and credential/settings
+// persistence is OFF. The fields map directly onto runFlags when the shared
+// runSandbox tail is invoked.
+type runImageFlags struct {
+	name            string
+	envForward      []string
+	memory          string
+	cpus            uint32
+	tmpSize         string
+	mcp             bool
+	mcpAuthzProfile string
+	mcpGroup        string
+	mcpPort         uint16
+	mcpConfig       string
+	mcpSessionTTL   time.Duration
+	egressProfile   string
+	allowHosts      []string
+	workspace       string
+	workspaceMode   string
+	review          bool
+	excludes        []string
+	yesAckDirect    bool
+	sshPort         uint16
+	ports           []string
+	cfgPath         string
+	debug           bool
+	logFile         string
+	noFirmwareDL    bool
+	noImageCache    bool
+	pull            string
+	traceEnabled    bool
+	timings         bool
+	// gitToken / gitSSHAgent are opt-in (default false): the inverse of the
+	// root command's --no-git-token / --no-git-ssh-agent. run-image forwards
+	// neither the git token nor the SSH agent into an arbitrary image unless
+	// explicitly requested (ephemeral, safer-by-default posture).
+	gitToken        bool
+	gitSSHAgent     bool
+	seedCredentials bool
+}
+
+// runImageCmd builds the `bbox run-image` subcommand. It boots an arbitrary
+// OCI image in a sandbox VM, runs the supplied command, forwards only
+// explicitly-requested env, and persists nothing — an ephemeral one-shot with
+// safer-than-custom defaults. The image is the first positional arg; the
+// command (required) follows a literal `--`.
+func runImageCmd() *cobra.Command {
+	var (
+		f         runImageFlags
+		envFwd    []string
+		envFwdAlt []string
+	)
+	cmd := &cobra.Command{
+		Use:   "run-image IMAGE [flags] -- CMD [args...]",
+		Short: "Run an arbitrary OCI image as an ephemeral sandbox one-shot",
+		Long: `bbox run-image boots an arbitrary OCI image in a hardware-isolated
+microVM, runs CMD inside it, and persists nothing. It builds an in-memory
+agent from the flags (no config-file mutation, no registry persistence) and
+runs it through the normal sandbox path.
+
+Ephemeral defaults (safer than a custom agent):
+  - credential persistence OFF
+  - host settings import OFF
+  - env forwarding EMPTY (forward nothing) — opt in with --env
+  - git token / SSH agent OFF — opt in with --git-token / --git-ssh-agent
+  - MCP proxy OFF — opt in with --mcp
+  - egress PERMISSIVE (disclosed on stderr) — tighten with --egress-profile
+
+The image is the first positional argument. The command to run inside the VM
+follows a literal "--" and is required.
+
+Example:
+  bbox run-image ghcr.io/jbarslox/aider-bbox:latest -- aider
+  bbox run-image ubuntu:24.04 --env OPENAI_API_KEY --egress-profile standard --allow-host api.openai.com:443 -- python -m http.server
+
+See: docs/run-image.md (minimum image contract)`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dash := cmd.ArgsLenAtDash()
+			if dash < 0 {
+				return errors.New("run-image requires a command after \"--\" (e.g. bbox run-image IMAGE -- CMD)")
+			}
+			image := args[0]
+			command := args[dash:]
+			if len(command) == 0 {
+				return errors.New("run-image requires a non-empty command after \"--\"")
+			}
+			// --env and --env-forward both append to the same forwarding list.
+			f.envForward = append(append([]string{}, envFwd...), envFwdAlt...)
+			f.traceEnabled = f.traceEnabled || os.Getenv("BBOX_TRACE") == "1"
+			return runRunImage(cmd.Context(), image, command, f)
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	cmd.Flags().StringVar(&f.name, "name", "", "Agent name (VM name, logs, BBOX_AGENT_NAME); defaults to the image repo basename")
+	cmd.Flags().StringSliceVar(&envFwd, "env", nil, "Forward a host env var into the VM (exact name or glob like 'PREFIX_*', repeatable)")
+	cmd.Flags().StringSliceVar(&envFwdAlt, "env-forward", nil, "Alias for --env (repeatable)")
+	cmd.Flags().Uint32Var(&f.cpus, "cpus", 0, "Number of vCPUs (0 = agent default)")
+	cmd.Flags().StringVar(&f.memory, "memory", "", "RAM for the VM, e.g. 4g or 512m (empty = agent default)")
+	cmd.Flags().StringVar(&f.tmpSize, "tmp-size", "", "Size of /tmp tmpfs inside the VM, e.g. 512m or 2g (empty = agent default)")
+	cmd.Flags().BoolVar(&f.mcp, "mcp", false, "Enable the MCP tool proxy (off by default; forces mcp.mode=env)")
+	cmd.Flags().StringVar(&f.mcpAuthzProfile, "mcp-authz-profile", "", "MCP authorization profile: full-access, observe, safe-tools, custom (default: safe-tools for run-image)")
+	cmd.Flags().StringVar(&f.mcpGroup, "mcp-group", "default", "ToolHive group to discover MCP servers from")
+	cmd.Flags().Uint16Var(&f.mcpPort, "mcp-port", 4483, "Port for MCP proxy on VM gateway")
+	cmd.Flags().StringVar(&f.mcpConfig, "mcp-config", "", "Path to MCP config YAML (Cedar policies and aggregation settings)")
+	cmd.Flags().DurationVar(&f.mcpSessionTTL, "mcp-session-ttl", 0, "Idle timeout for host MCP sessions, e.g. 12h or 30m (0 = default 12h)")
+	cmd.Flags().StringVar(&f.egressProfile, "egress-profile", "permissive", "Egress restriction level: permissive, standard, locked (default: permissive)")
+	cmd.Flags().StringSliceVar(&f.allowHosts, "allow-host", nil, "Additional allowed egress DNS hostname[:port] — no IP addresses (repeatable)")
+	cmd.Flags().StringVar(&f.workspace, "workspace", "", "Workspace directory to mount (default: current directory)")
+	cmd.Flags().StringVar(&f.workspaceMode, "workspace-mode", "", "Workspace isolation mode: snapshot (default), direct")
+	cmd.Flags().BoolVar(&f.review, "review", false, "Enable interactive per-file review of workspace changes (snapshot mode only)")
+	cmd.Flags().StringSliceVar(&f.excludes, "exclude", nil, "Additional exclude patterns for workspace snapshot (repeatable, snapshot mode only)")
+	cmd.Flags().BoolVar(&f.yesAckDirect, "yes", false, "Acknowledge dangerous options without prompting (required on first --workspace-mode=direct run)")
+	cmd.Flags().Uint16Var(&f.sshPort, "ssh-port", 0, "Host SSH port (0 = auto-pick)")
+	cmd.Flags().StringSliceVar(&f.ports, "port", nil, "Forward an additional TCP port from guest to host as HOST:GUEST, bound to 127.0.0.1 (repeatable)")
+	cmd.Flags().StringVar(&f.cfgPath, "config", "", "Config file path (default: ~/.config/broodbox/config.yaml; loaded for defaults)")
+	cmd.Flags().BoolVar(&f.debug, "debug", false, "Enable debug-level logging to file (default: info level)")
+	cmd.Flags().StringVar(&f.logFile, "log-file", "", "Override log file path (default: ~/.config/broodbox/vms/<vm-name>/broodbox.log)")
+	cmd.Flags().BoolVar(&f.noFirmwareDL, "no-firmware-download", false, "Disable firmware download (use system libkrunfw only)")
+	cmd.Flags().BoolVar(&f.noImageCache, "no-image-cache", false, "Disable OCI image caching (fresh pull every run)")
+	cmd.Flags().StringVar(&f.pull, "pull", "", "Image pull policy: always, background, if-not-present, never (default: background)")
+	cmd.Flags().BoolVar(&f.traceEnabled, "trace", false, "Enable OpenTelemetry tracing (writes trace.json to VM data dir)")
+	cmd.Flags().BoolVar(&f.timings, "timings", false, "Print per-phase timing summary after run")
+	// Opt-in forwarding: defaults to OFF for run-image (safer ephemeral
+	// posture) — the inverse of the root command's --no-git-token flag.
+	cmd.Flags().BoolVar(&f.gitToken, "git-token", false, "Forward GITHUB_TOKEN/GH_TOKEN into the VM (off by default for run-image)")
+	cmd.Flags().BoolVar(&f.gitSSHAgent, "git-ssh-agent", false, "Forward the SSH agent into the VM (off by default for run-image)")
+	cmd.Flags().BoolVar(&f.seedCredentials, "seed-credentials", false, "Seed agent credentials from host (e.g. macOS Keychain) into the VM")
+	return cmd
+}
+
+// runRunImage is the run-image front-end. It resolves the agent name (from
+// --name or derived from the image), validates the image ref, builds an
+// in-memory AgentOverride with ephemeral defaults via the pure
+// buildRunImageOverride, validates it (ValidateCustomAgent), maps it to an
+// agent.Agent (AgentFromOverride), registers it as a data-only entry on the
+// resolved registry, injects the override into the merged config so the
+// sandbox layer observes mcp.mode=env, then drives the shared runSandbox tail.
+func runRunImage(parentCtx context.Context, image string, command []string, f runImageFlags) error {
+	ctx, cancel := signal.NotifyContext(parentCtx, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// run-image is ephemeral: credential persistence is always OFF (the
+	// credential store is never created), so --seed-credentials would be a
+	// silent no-op. Reject it at parse time rather than mislead the operator.
+	if f.seedCredentials {
+		return errors.New("--seed-credentials is incompatible with run-image: credential persistence is always off for ephemeral runs")
+	}
+
+	// Validate the image reference syntactically (no network I/O).
+	if err := imageRefValidator(image); err != nil {
+		return fmt.Errorf("invalid image reference %q: %w (OCI references must be lowercase; see docs/run-image.md)", image, err)
+	}
+
+	// Resolve agent name: --name wins, otherwise derive from the image ref.
+	agentName := f.name
+	nameFromFlag := agentName != ""
+	if !nameFromFlag {
+		agentName = deriveAgentName(image)
+	}
+	if err := agent.ValidateName(agentName); err != nil {
+		if nameFromFlag {
+			return fmt.Errorf("invalid agent name %q: %w", agentName, err)
+		}
+		return fmt.Errorf("invalid agent name %q (derived from image; pass --name to override): %w", agentName, err)
+	}
+	// Disclose the resolved agent name on stderr. The name drives the VM name,
+	// logs, and BBOX_AGENT_NAME, so surfacing it lets the operator catch a
+	// surprising derivation before the run starts.
+	if nameFromFlag {
+		_, _ = fmt.Fprintf(os.Stderr, "Agent: %s\n", agentName)
+	} else {
+		_, _ = fmt.Fprintf(os.Stderr, "Agent: %s (derived from image; pass --name to override)\n", agentName)
+	}
+
+	// Validate --pull, --env-forward, --ports, --workspace-mode up front,
+	// mirroring run().
+	if f.pull != "" && !domainconfig.IsValidPullPolicy(f.pull) {
+		return fmt.Errorf("invalid --pull %q: valid values are %v",
+			f.pull, domainconfig.ValidPullPolicies())
+	}
+	if err := agent.ValidateEnvForwardPatterns(f.envForward); err != nil {
+		return fmt.Errorf("invalid --env: %w", err)
+	}
+	parsedPorts, portsErr := parsePortForwards(f.ports)
+	if portsErr != nil {
+		return portsErr
+	}
+	if f.noImageCache && f.pull == domainconfig.PullNever {
+		return fmt.Errorf("--no-image-cache and --pull=never are incompatible: "+
+			"pull policy %q requires a cache to serve hits", domainconfig.PullNever)
+	}
+	if f.workspaceMode != "" && !domainconfig.IsValidWorkspaceMode(f.workspaceMode) {
+		return fmt.Errorf("invalid --workspace-mode %q: valid values are %v",
+			f.workspaceMode, domainconfig.ValidWorkspaceModes())
+	}
+	if f.workspaceMode == domainconfig.WorkspaceModeDirect {
+		if f.review {
+			return errors.New("--review has no effect in direct mode: there is no snapshot to review against. " +
+				"Remove --review or drop --workspace-mode=direct")
+		}
+		if len(f.excludes) > 0 {
+			return errors.New("--exclude applies to snapshot matching and is ignored in direct mode. " +
+				"Remove --exclude or drop --workspace-mode=direct")
+		}
+	}
+	if f.mcpAuthzProfile != "" || f.mcpSessionTTL != 0 {
+		if err := validateMCPFlags(f.mcpAuthzProfile, f.mcpSessionTTL); err != nil {
+			return err
+		}
+	}
+
+	// Resolve workspace early for VM naming.
+	earlyWs := f.workspace
+	if earlyWs == "" {
+		var wdErr error
+		earlyWs, wdErr = os.Getwd()
+		if wdErr != nil {
+			return fmt.Errorf("getting current directory: %w", wdErr)
+		}
+	}
+
+	var sessionBytes [4]byte
+	if _, err := rand.Read(sessionBytes[:]); err != nil {
+		return fmt.Errorf("generating session ID: %w", err)
+	}
+	sessionID := fmt.Sprintf("%x", sessionBytes)
+	vmName := sandbox.VMName(agentName, earlyWs, sessionID)
+
+	logPath, logFile, logCloser, err := openLogFile(f.logFile, vmName)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Warning: could not open log file: %s\n", err)
+	}
+	if logCloser != nil {
+		defer func() { _ = logCloser.Close() }()
+	}
+	logger := setupLogger(logFile, f.debug).With("vm", vmName)
+	slog.SetDefault(logger)
+	_, _ = fmt.Fprintf(os.Stderr, "Session log: %s\n", logPath)
+
+	terminal := infraterminal.NewOSTerminal(os.Stdin, os.Stdout, os.Stderr)
+	observer := chooseObserver(terminal)
+
+	var timingObs *infraprogress.TimingObserver
+	if f.timings {
+		timingObs = infraprogress.NewTimingObserver(observer)
+		observer = timingObs
+		defer timingObs.Summary(os.Stderr)
+	}
+
+	var tracerProvider *sdktrace.TracerProvider
+	if f.traceEnabled {
+		tracePath := filepath.Join(filepath.Dir(logPath), "trace.json")
+		tp, tpErr := infratracing.NewProvider(tracePath)
+		if tpErr != nil {
+			logger.Warn("failed to initialize tracing", "error", tpErr)
+		} else {
+			tracerProvider = tp
+			otel.SetTracerProvider(tp)
+			defer infratracing.Shutdown(context.Background(), tp)
+			_, _ = fmt.Fprintf(os.Stderr, "Trace output: %s\n", tracePath)
+		}
+	}
+
+	ws := earlyWs
+
+	snapDir, snapDirErr := snapshotCacheDir()
+	if snapDirErr != nil {
+		return fmt.Errorf("resolving snapshot cache directory: %w", snapDirErr)
+	}
+	infraws.CleanupStaleSnapshots(snapDir, logger)
+
+	if os.Getenv("BBOX_KEEP_VM_DATA") == "1" {
+		logger.Debug("BBOX_KEEP_VM_DATA set, skipping stale VM directory cleanup")
+	} else if home, homeErr := os.UserHomeDir(); homeErr == nil {
+		vmsDir := filepath.Join(home, ".config", "broodbox", "vms")
+		go func() {
+			start := time.Now()
+			logger.Debug("starting stale VM directory cleanup", "vms_dir", vmsDir)
+			infravm.CleanupStaleVMDirs(vmsDir, vmName, logger)
+			logger.Debug("finished stale VM directory cleanup",
+				"vms_dir", vmsDir, "elapsed", time.Since(start))
+		}()
+	}
+
+	// Load global + workspace-local config for defaults (egress hosts, MCP
+	// defaults, resource ceilings). Custom agents declared in config are also
+	// registered so the run-image agent does not collide with them silently.
+	resolved, err := buildResolvedRegistry(f.cfgPath, ws, logger, os.Stderr)
+	if err != nil {
+		return err
+	}
+	registry := resolved.registry
+	cfg := resolved.merged
+
+	// Reject a name that collides with ANY already-registered agent (built-in
+	// OR config-declared custom). A data-only run-image entry would shadow a
+	// built-in's plugin (MCP injector / seeder) or silently overwrite a custom
+	// agent's definition via registry.Add. Force a distinct name.
+	if err := checkAgentNameCollision(registry, agentName, nameFromFlag); err != nil {
+		return err
+	}
+
+	// Build the ephemeral AgentOverride from the flags (pure).
+	override, buildErr := buildRunImageOverride(image, command, f)
+	if buildErr != nil {
+		return buildErr
+	}
+	if err := domainconfig.ValidateCustomAgent(agentName, override, imageRefValidator); err != nil {
+		return fmt.Errorf("validating run-image agent: %w", err)
+	}
+	ag, err := domainconfig.AgentFromOverride(agentName, override, cfg.Defaults)
+	if err != nil {
+		return fmt.Errorf("building run-image agent: %w", err)
+	}
+	if err := registry.Add(ag); err != nil {
+		return fmt.Errorf("registering run-image agent: %w", err)
+	}
+
+	// Inject the override into the merged config so the sandbox layer observes
+	// the run-image-specific fields it reads per-agent (notably mcp.mode=env,
+	// which gates the gateway-only egress fallback in Prepare). This is an
+	// in-memory mutation of the resolved config; nothing is written to disk.
+	//
+	// MergeConfigs shallow-copies: when the workspace-local config declares no
+	// agents, merged.Agents aliases global.Agents. Mutating it in place would
+	// leak the run-image override back into the global config object. Detach
+	// the map first so this run's ephemeral entry stays local to this run.
+	detached := make(map[string]domainconfig.AgentOverride, len(cfg.Agents)+1)
+	for k, v := range cfg.Agents {
+		detached[k] = v
+	}
+	cfg.Agents = detached
+	cfg.Agents[agentName] = override
+
+	// Resolve effective workspace mode / review / excludes, mirroring run().
+	effectiveMode := f.workspaceMode
+	if effectiveMode == "" {
+		if cfg != nil {
+			effectiveMode = cfg.Workspace.ResolvedWorkspaceMode()
+		} else {
+			effectiveMode = domainconfig.WorkspaceModeSnapshot
+		}
+	}
+	directMode := effectiveMode == domainconfig.WorkspaceModeDirect
+
+	interactiveReview := f.review
+	if !interactiveReview && cfg != nil && cfg.Review.Enabled != nil && *cfg.Review.Enabled {
+		interactiveReview = true
+	}
+	if directMode {
+		if interactiveReview {
+			_, _ = fmt.Fprintln(os.Stderr,
+				"Warning: review.enabled is ignored in direct mode (no snapshot to review against).")
+		}
+		interactiveReview = false
+		if err := ensureDirectModeAck(f.yesAckDirect, logger); err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(os.Stderr,
+			"! Direct mode: agent writes directly to %s. No snapshot, no review, no undo.\n",
+			ws,
+		)
+	}
+
+	var excludePatterns []string
+	if cfg != nil {
+		excludePatterns = append(excludePatterns, cfg.Review.ExcludePatterns...)
+	}
+	excludePatterns = append(excludePatterns, f.excludes...)
+
+	var snapshotMatcher, diffMatcher snapshot.Matcher
+	if !directMode {
+		excludeCfg, excludeErr := exclude.LoadExcludeConfig(ws, excludePatterns, logger)
+		if excludeErr != nil {
+			return fmt.Errorf("loading exclude config: %w", excludeErr)
+		}
+		snapshotMatcher = exclude.NewMatcherFromConfig(excludeCfg)
+
+		gitignorePatterns, gitignoreErr := exclude.LoadGitignorePatterns(ws, logger)
+		if gitignoreErr != nil {
+			logger.Warn("failed to load .gitignore patterns", "error", gitignoreErr)
+		}
+		diffMatcher = exclude.NewDiffMatcher(excludeCfg, gitignorePatterns)
+	}
+
+	configEgressHosts, egressErr := domainconfig.ToEgressHosts(cfg.Network.AllowHosts)
+	if egressErr != nil {
+		return fmt.Errorf("config network.%w", egressErr)
+	}
+
+	// Disclose the permissive egress default so the operator notices. Printed
+	// to stderr unconditionally (even when piped) because it is a security
+	// disclosure, not progress noise.
+	if f.egressProfile == "" || f.egressProfile == string(egress.ProfilePermissive) {
+		_, _ = fmt.Fprintln(os.Stderr,
+			"Egress: permissive — the agent has unrestricted outbound network. "+
+				"Use --egress-profile standard --allow-host ... to restrict.")
+	}
+
+	// Disclose opt-in secret forwarding into an arbitrary image. Both are OFF
+	// by default for run-image; only print when the operator opted in.
+	if f.gitToken {
+		_, _ = fmt.Fprintln(os.Stderr, "Forwarding GITHUB_TOKEN/GH_TOKEN into the VM")
+	}
+	if f.gitSSHAgent {
+		_, _ = fmt.Fprintln(os.Stderr, "Forwarding SSH agent into the VM")
+	}
+
+	// Map run-image flags onto the shared runFlags and drive runSandbox.
+	flags := runFlags{
+		cpus:            f.cpus,
+		memory:          f.memory,
+		tmpSize:         f.tmpSize,
+		workspace:       f.workspace,
+		sshPort:         f.sshPort,
+		cfgPath:         f.cfgPath,
+		image:           "", // image is already baked into the registered agent
+		debug:           f.debug,
+		review:          f.review,
+		workspaceMode:   f.workspaceMode,
+		yesAckDirect:    f.yesAckDirect,
+		excludes:        f.excludes,
+		logFile:         f.logFile,
+		egressProfile:   f.egressProfile,
+		allowHosts:      f.allowHosts,
+		noMCP:           !f.mcp,
+		mcpGroup:        f.mcpGroup,
+		mcpPort:         f.mcpPort,
+		mcpConfig:       f.mcpConfig,
+		mcpAuthzProfile: f.mcpAuthzProfile,
+		mcpSessionTTL:   f.mcpSessionTTL,
+		// Opt-in inversion: run-image forwards neither by default, so the
+		// shared runSandbox path (which negates these against the config
+		// default) sees noGitToken/noGitSSHAgent true unless the operator
+		// explicitly opted in.
+		noGitToken:        !f.gitToken,
+		noGitSSHAgent:     !f.gitSSHAgent,
+		noSaveCredentials: true,  // ephemeral: never persist credentials
+		seedCredentials:   false, // ephemeral: --seed-credentials already rejected above
+		noSettings:        true,  // ephemeral: never inject host settings
+		noFirmwareDL:      f.noFirmwareDL,
+		noImageCache:      f.noImageCache,
+		pull:              f.pull,
+		traceEnabled:      f.traceEnabled,
+		timings:           f.timings,
+		exec:              "", // command is baked into the registered agent
+		commandArgs:       nil,
+		envForward:        f.envForward,
+		ports:             f.ports,
+	}
+
+	return runSandbox(ctx, sandboxRunInput{
+		agentName:         agentName,
+		flags:             flags,
+		registry:          registry,
+		cfg:               cfg,
+		ws:                ws,
+		snapDir:           snapDir,
+		vmName:            vmName,
+		sessionID:         sessionID,
+		logPath:           logPath,
+		logFile:           logFile,
+		logger:            logger,
+		observer:          observer,
+		timingObs:         timingObs,
+		tracerProvider:    tracerProvider,
+		terminal:          terminal,
+		directMode:        directMode,
+		interactiveReview: interactiveReview,
+		snapshotMatcher:   snapshotMatcher,
+		diffMatcher:       diffMatcher,
+		configEgressHosts: configEgressHosts,
+		parsedPorts:       parsedPorts,
+	})
+}
+
+// buildRunImageOverride maps run-image flags into an AgentOverride carrying
+// the ephemeral defaults. It is pure (no I/O, no go-containerregistry) so it
+// can be table-tested directly. The image is accepted pre-validated; image-ref
+// parsing stays in the caller (runRunImage via imageRefValidator).
+//
+// Ephemeral defaults baked in here:
+//   - EnvForward: from --env / --env-forward only (empty by default)
+//   - EgressProfile: "permissive" unless overridden (so the bare
+//     `bbox run-image IMG -- cmd` example boots without declaring egress_hosts)
+//   - MCP: when --mcp is set, MCP.Mode is forced to "env" (no config-file
+//     injector exists for an arbitrary image; the agent discovers the proxy via
+//     BBOX_MCP_URL). When --mcp is unset, MCP is left nil and runSandbox gates
+//     it off via the noMCP flag.
+//   - Credential persistence and settings import are OFF (handled in runSandbox
+//     via noSaveCredentials/noSettings on runFlags, not via the override).
+func buildRunImageOverride(image string, command []string, f runImageFlags) (domainconfig.AgentOverride, error) {
+	if image == "" {
+		return domainconfig.AgentOverride{}, errors.New("image is required")
+	}
+	if len(command) == 0 {
+		return domainconfig.AgentOverride{}, errors.New("command is required")
+	}
+
+	o := domainconfig.AgentOverride{
+		Image:       image,
+		Description: "ephemeral run-image agent",
+		Command:     append([]string(nil), command...),
+		EnvForward:  append([]string(nil), f.envForward...),
+	}
+
+	// Egress profile defaults to permissive for the ephemeral UX; an explicit
+	// --egress-profile (validated upstream) wins. An empty f.egressProfile
+	// cannot happen (the flag default is "permissive"), but guard anyway.
+	profile := f.egressProfile
+	if profile == "" {
+		profile = string(egress.ProfilePermissive)
+	}
+	o.EgressProfile = profile
+
+	// Resource overrides: only set when the operator supplied them so the
+	// custom-agent floor (2 vCPU / 4096 MiB) applies otherwise.
+	if f.cpus > 0 {
+		o.CPUs = f.cpus
+	}
+	if f.memory != "" {
+		parsed, err := bytesize.ParseByteSize(f.memory)
+		if err != nil {
+			return domainconfig.AgentOverride{}, fmt.Errorf("--memory: %w", err)
+		}
+		o.Memory = parsed
+	}
+	if f.tmpSize != "" {
+		parsed, err := bytesize.ParseByteSize(f.tmpSize)
+		if err != nil {
+			return domainconfig.AgentOverride{}, fmt.Errorf("--tmp-size: %w", err)
+		}
+		o.TmpSize = parsed
+	}
+
+	// MCP: --mcp forces mode=env so the proxy is exposed only via BBOX_MCP_URL
+	// (no config-file injector for an arbitrary image). Authz is resolved at
+	// runSandbox wiring; the per-agent Authz override is set only when the
+	// operator supplied --mcp-authz-profile.
+	if f.mcp {
+		o.MCP = &domainconfig.MCPAgentOverride{
+			Mode: domainconfig.MCPModeEnv,
+		}
+		if f.mcpAuthzProfile != "" {
+			o.MCP.Authz = &domainconfig.MCPAuthzConfig{Profile: f.mcpAuthzProfile}
+		}
+	}
+
+	return o, nil
+}
+
+// validateMCPFlags validates the MCP authz-profile and session-TTL flag values.
+// It is pure and shared by run() and runRunImage front-ends so the two commands
+// don't drift; runSandbox re-checks the same as defence-in-depth (it is the
+// primary guard for the run() path, which does not validate up front).
+func validateMCPFlags(profile string, ttl time.Duration) error {
+	if profile != "" && !domainconfig.IsValidMCPAuthzProfile(profile) {
+		return fmt.Errorf("invalid --mcp-authz-profile %q: valid values are %v",
+			profile, domainconfig.ValidMCPAuthzProfiles())
+	}
+	if ttl < 0 {
+		return fmt.Errorf("--mcp-session-ttl must be non-negative, got %s", ttl)
+	}
+	return nil
+}
+
+// checkAgentNameCollision rejects a run-image agent name that collides with any
+// already-registered agent (built-in OR config-declared custom). A data-only
+// run-image entry would shadow a built-in's plugin or silently overwrite a
+// custom agent via registry.Add. The message distinguishes an explicit --name
+// from a derived name so the operator knows how to fix it. Pure with respect to
+// the registry (only calls Get).
+func checkAgentNameCollision(registry *infraagent.Registry, agentName string, nameFromFlag bool) error {
+	if _, lookupErr := registry.Get(agentName); lookupErr == nil {
+		if nameFromFlag {
+			return fmt.Errorf("--name %q is already in use; choose a different name", agentName)
+		}
+		return fmt.Errorf("derived agent name %q collides with an existing agent; pass --name to override", agentName)
+	}
+	return nil
+}
+
+// deriveAgentName produces an agent name from an OCI image reference by taking
+// the repository basename (last path segment, after stripping any tag/digest),
+// lower-casing it, replacing runs of non-[a-z0-9-] with '-', and collapsing /
+// trimming surrounding '-'. It is pure string manipulation — it does NOT call
+// go-containerregistry — so refs that ParseReference rejects as invalid
+// (uppercase, ad-hoc registries) still yield a usable name. When the result is
+// empty or degenerate the caller should fall back.
+//
+// Example: "ghcr.io/me/Aider-Bbox:latest" -> "aider-bbox".
+func deriveAgentName(imageRef string) string {
+	s := imageRef
+	// Strip a digest suffix ("@sha256:...").
+	if i := strings.LastIndex(s, "@"); i >= 0 {
+		s = s[:i]
+	}
+	// Strip a tag (":tag") — but only the colon after the last '/', so a
+	// registry port ("registry:5000/...") is not mistaken for a tag.
+	if lastSlash := strings.LastIndex(s, "/"); lastSlash >= 0 {
+		tail := s[lastSlash+1:]
+		if i := strings.LastIndex(tail, ":"); i >= 0 {
+			tail = tail[:i]
+		}
+		s = tail
+	} else if i := strings.LastIndex(s, ":"); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.ToLower(s)
+	// Replace runs of invalid chars with '-'.
+	var b strings.Builder
+	b.Grow(len(s))
+	prevDash := false
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			prevDash = false
+		} else {
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "run-image"
+	}
+	return out
+}

--- a/cmd/bbox/run_image.go
+++ b/cmd/bbox/run_image.go
@@ -127,6 +127,11 @@ See: docs/run-image.md (minimum image contract)`,
 			// --env and --env-forward both append to the same forwarding list.
 			f.envForward = append(append([]string{}, envFwd...), envFwdAlt...)
 			f.traceEnabled = f.traceEnabled || os.Getenv("BBOX_TRACE") == "1"
+			if ignored := mcpSubFlagsWithoutMCP(cmd, f.mcp); len(ignored) > 0 {
+				_, _ = fmt.Fprintf(os.Stderr,
+					"Warning: %s ignored without --mcp (the MCP proxy is off by default for run-image)\n",
+					strings.Join(ignored, ", "))
+			}
 			return runRunImage(cmd.Context(), image, command, f)
 		},
 		SilenceUsage:  true,
@@ -450,21 +455,25 @@ func runRunImage(parentCtx context.Context, image string, command []string, f ru
 
 	// Map run-image flags onto the shared runFlags and drive runSandbox.
 	flags := runFlags{
-		cpus:            f.cpus,
-		memory:          f.memory,
-		tmpSize:         f.tmpSize,
-		workspace:       f.workspace,
-		sshPort:         f.sshPort,
-		cfgPath:         f.cfgPath,
-		image:           "", // image is already baked into the registered agent
-		debug:           f.debug,
-		review:          f.review,
-		workspaceMode:   f.workspaceMode,
-		yesAckDirect:    f.yesAckDirect,
-		excludes:        f.excludes,
-		logFile:         f.logFile,
-		egressProfile:   f.egressProfile,
-		allowHosts:      f.allowHosts,
+		cpus:          f.cpus,
+		memory:        f.memory,
+		tmpSize:       f.tmpSize,
+		workspace:     f.workspace,
+		sshPort:       f.sshPort,
+		cfgPath:       f.cfgPath,
+		image:         "", // image is already baked into the registered agent
+		debug:         f.debug,
+		review:        f.review,
+		workspaceMode: f.workspaceMode,
+		yesAckDirect:  f.yesAckDirect,
+		excludes:      f.excludes,
+		logFile:       f.logFile,
+		egressProfile: f.egressProfile,
+		// allowHosts is intentionally nil here: buildRunImageOverride already
+		// filed --allow-host under override.EgressHosts[profile], which
+		// runSandbox reads via ag.EgressHosts. Leaving this set would land the
+		// same hosts a second time via opts.AllowHosts (sandbox.go extraHosts).
+		allowHosts:      nil,
 		noMCP:           !f.mcp,
 		mcpGroup:        f.mcpGroup,
 		mcpPort:         f.mcpPort,
@@ -520,11 +529,17 @@ func runRunImage(parentCtx context.Context, image string, command []string, f ru
 // the ephemeral defaults. It is pure (no I/O, no go-containerregistry) so it
 // can be table-tested directly. The image is accepted pre-validated; image-ref
 // parsing stays in the caller (runRunImage via imageRefValidator).
+// egress.ParseHostFlag is pure string parsing (no I/O), so folding
+// --allow-host into EgressHosts below preserves purity.
 //
 // Ephemeral defaults baked in here:
 //   - EnvForward: from --env / --env-forward only (empty by default)
 //   - EgressProfile: "permissive" unless overridden (so the bare
 //     `bbox run-image IMG -- cmd` example boots without declaring egress_hosts)
+//   - EgressHosts: --allow-host entries, filed under the selected profile.
+//     run-image has no config file to declare egress_hosts, so --allow-host is
+//     the only way to satisfy ValidateCustomAgent's "non-permissive profile
+//     needs hosts" gate (pkg/domain/config/custom_agent.go).
 //   - MCP: when --mcp is set, MCP.Mode is forced to "env" (no config-file
 //     injector exists for an arbitrary image; the agent discovers the proxy via
 //     BBOX_MCP_URL). When --mcp is unset, MCP is left nil and runSandbox gates
@@ -554,6 +569,23 @@ func buildRunImageOverride(image string, command []string, f runImageFlags) (dom
 		profile = string(egress.ProfilePermissive)
 	}
 	o.EgressProfile = profile
+
+	// File --allow-host entries under the selected profile so
+	// ValidateCustomAgent sees them: run-image has no config file to declare
+	// egress_hosts, so --allow-host is the only host source available here.
+	if len(f.allowHosts) > 0 {
+		cfgs := make([]domainconfig.EgressHostConfig, 0, len(f.allowHosts))
+		for _, h := range f.allowHosts {
+			parsed, err := egress.ParseHostFlag(h)
+			if err != nil {
+				return domainconfig.AgentOverride{}, fmt.Errorf("--allow-host %q: %w", h, err)
+			}
+			cfgs = append(cfgs, domainconfig.EgressHostConfig{
+				Name: parsed.Name, Ports: parsed.Ports, Protocol: parsed.Protocol,
+			})
+		}
+		o.EgressHosts = map[string][]domainconfig.EgressHostConfig{profile: cfgs}
+	}
 
 	// Resource overrides: only set when the operator supplied them so the
 	// custom-agent floor (2 vCPU / 4096 MiB) applies otherwise.
@@ -604,6 +636,24 @@ func validateMCPFlags(profile string, ttl time.Duration) error {
 		return fmt.Errorf("--mcp-session-ttl must be non-negative, got %s", ttl)
 	}
 	return nil
+}
+
+// mcpSubFlagsWithoutMCP returns the MCP sub-flag names the operator explicitly
+// set (via cmd.Flags().Changed) when mcp is false. --mcp-group and --mcp-port
+// have non-zero defaults, so detecting "set" requires Changed rather than a
+// zero-value comparison. An empty/nil result means either mcp is true or no
+// sub-flag was set, in which case the caller prints nothing.
+func mcpSubFlagsWithoutMCP(cmd *cobra.Command, mcp bool) []string {
+	if mcp {
+		return nil
+	}
+	var set []string
+	for _, name := range []string{"mcp-authz-profile", "mcp-group", "mcp-port", "mcp-config", "mcp-session-ttl"} {
+		if cmd.Flags().Changed(name) {
+			set = append(set, "--"+name)
+		}
+	}
+	return set
 }
 
 // checkAgentNameCollision rejects a run-image agent name that collides with any

--- a/cmd/bbox/run_image_test.go
+++ b/cmd/bbox/run_image_test.go
@@ -174,6 +174,48 @@ func TestBuildRunImageOverride(t *testing.T) {
 		}
 	})
 
+	t.Run("allow-host folded into EgressHosts under selected profile", func(t *testing.T) {
+		t.Parallel()
+		f := baseFlags
+		f.egressProfile = "standard"
+		f.allowHosts = []string{"api.openai.com:443"}
+		o, err := buildRunImageOverride(image, cmd, f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		hosts := o.EgressHosts["standard"]
+		if len(hosts) != 1 {
+			t.Fatalf("EgressHosts[standard] = %v, want 1 entry", hosts)
+		}
+		if hosts[0].Name != "api.openai.com" {
+			t.Errorf("Name = %q, want api.openai.com", hosts[0].Name)
+		}
+		if len(hosts[0].Ports) != 1 || hosts[0].Ports[0] != 443 {
+			t.Errorf("Ports = %v, want [443]", hosts[0].Ports)
+		}
+	})
+
+	t.Run("invalid allow-host rejected", func(t *testing.T) {
+		t.Parallel()
+		f := baseFlags
+		f.egressProfile = "standard"
+		f.allowHosts = []string{"1.2.3.4"}
+		if _, err := buildRunImageOverride(image, cmd, f); err == nil {
+			t.Error("expected error for IP-address --allow-host, got nil")
+		}
+	})
+
+	t.Run("no allow-host leaves EgressHosts nil", func(t *testing.T) {
+		t.Parallel()
+		o, err := buildRunImageOverride(image, cmd, baseFlags)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.EgressHosts != nil {
+			t.Errorf("EgressHosts = %v, want nil", o.EgressHosts)
+		}
+	})
+
 	t.Run("empty image rejected", func(t *testing.T) {
 		t.Parallel()
 		if _, err := buildRunImageOverride("", cmd, baseFlags); err == nil {
@@ -239,6 +281,24 @@ func TestBuildRunImageOverride_ValidateCustomAgent(t *testing.T) {
 		}
 		if err := domainconfig.ValidateCustomAgent("tool", o, imageRefValidator); err == nil {
 			t.Error("expected validation error for bad image ref, got nil")
+		}
+	})
+
+	t.Run("standard profile with allow-host passes validation without mcp", func(t *testing.T) {
+		t.Parallel()
+		// Regression: --egress-profile standard --allow-host HOST -- CMD used to
+		// fail ValidateCustomAgent because buildRunImageOverride never folded
+		// --allow-host into o.EgressHosts, leaving the "standard" profile
+		// hostless. --mcp is deliberately NOT set here — this is the documented
+		// run-image example (README.md / docs/run-image.md / --help) and it must
+		// not require enabling MCP just to satisfy the egress-hosts gate.
+		f := runImageFlags{egressProfile: "standard", allowHosts: []string{"api.openai.com:443"}}
+		o, err := buildRunImageOverride(image, cmd, f)
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		if err := domainconfig.ValidateCustomAgent("tool", o, imageRefValidator); err != nil {
+			t.Fatalf("ValidateCustomAgent: %v", err)
 		}
 	})
 
@@ -327,6 +387,81 @@ func TestRunImageCmd_ArgParsing(t *testing.T) {
 			t.Error("expected error for no args, got nil")
 		}
 	})
+}
+
+func TestMCPSubFlagsWithoutMCP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "no flags set, mcp off",
+			args: []string{"ghcr.io/x/y:latest", "--", "run"},
+			want: nil,
+		},
+		{
+			name: "mcp-authz-profile set without --mcp",
+			args: []string{"ghcr.io/x/y:latest", "--mcp-authz-profile", "observe", "--", "run"},
+			want: []string{"--mcp-authz-profile"},
+		},
+		{
+			name: "mcp-group set without --mcp (non-zero default still detected via Changed)",
+			args: []string{"ghcr.io/x/y:latest", "--mcp-group", "default", "--", "run"},
+			want: []string{"--mcp-group"},
+		},
+		{
+			name: "mcp-port set without --mcp (non-zero default still detected via Changed)",
+			args: []string{"ghcr.io/x/y:latest", "--mcp-port", "4483", "--", "run"},
+			want: []string{"--mcp-port"},
+		},
+		{
+			name: "multiple sub-flags set without --mcp",
+			args: []string{
+				"ghcr.io/x/y:latest",
+				"--mcp-authz-profile", "observe",
+				"--mcp-session-ttl", "30m",
+				"--mcp-config", "/tmp/x.yaml",
+				"--", "run",
+			},
+			want: []string{"--mcp-authz-profile", "--mcp-config", "--mcp-session-ttl"}, // declared order: authz-profile, group, port, config, session-ttl
+		},
+		{
+			name: "sub-flags set together with --mcp produce no warning",
+			args: []string{"ghcr.io/x/y:latest", "--mcp", "--mcp-authz-profile", "observe", "--", "run"},
+			want: nil,
+		},
+		{
+			name: "no sub-flags and no --mcp",
+			args: []string{"ghcr.io/x/y:latest", "--", "run"},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := runImageCmd()
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			mcp, err := cmd.Flags().GetBool("mcp")
+			if err != nil {
+				t.Fatalf("GetBool(mcp): %v", err)
+			}
+			got := mcpSubFlagsWithoutMCP(cmd, mcp)
+			if len(got) != len(tt.want) {
+				t.Fatalf("mcpSubFlagsWithoutMCP() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("mcpSubFlagsWithoutMCP()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
 }
 
 func TestRunImageCmd_FlagsRegistered(t *testing.T) {

--- a/cmd/bbox/run_image_test.go
+++ b/cmd/bbox/run_image_test.go
@@ -1,0 +1,666 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	infraagent "github.com/stacklok/brood-box/internal/infra/agent"
+	"github.com/stacklok/brood-box/pkg/clients"
+	domainconfig "github.com/stacklok/brood-box/pkg/domain/config"
+	"github.com/stacklok/brood-box/pkg/domain/egress"
+)
+
+func TestDeriveAgentName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "simple repo with tag", ref: "ghcr.io/me/Aider-Bbox:latest", want: "aider-bbox"},
+		{name: "dockerhub library", ref: "ubuntu:24.04", want: "ubuntu"},
+		{name: "bare name", ref: "ubuntu", want: "ubuntu"},
+		{name: "nested path", ref: "ghcr.io/stacklok/brood-box/claude-code", want: "claude-code"},
+		{name: "digest suffix", ref: "ghcr.io/acme/tool@sha256:abcdef", want: "tool"},
+		{name: "registry with port", ref: "registry.example.com:5000/foo/bar", want: "bar"},
+		{name: "underscores collapse", ref: "ghcr.io/acme/my_image:1", want: "my-image"},
+		{name: "uppercase lowercased", ref: "ghcr.io/acme/MyImage:1", want: "myimage"},
+		{name: "degenerate empty after trim", ref: "ghcr.io/acme/---:1", want: "run-image"},
+		{name: "registry port only yields host part", ref: "localhost:5000", want: "localhost"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := deriveAgentName(tt.ref)
+			if got != tt.want {
+				t.Errorf("deriveAgentName(%q) = %q, want %q", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildRunImageOverride(t *testing.T) {
+	t.Parallel()
+
+	baseFlags := runImageFlags{
+		egressProfile: "permissive",
+	}
+	image := "ghcr.io/acme/tool:latest"
+	cmd := []string{"aider"}
+
+	t.Run("defaults are ephemeral", func(t *testing.T) {
+		t.Parallel()
+		o, err := buildRunImageOverride(image, cmd, baseFlags)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.Image != image {
+			t.Errorf("Image = %q, want %q", o.Image, image)
+		}
+		if len(o.Command) != 1 || o.Command[0] != "aider" {
+			t.Errorf("Command = %v, want [aider]", o.Command)
+		}
+		if len(o.EnvForward) != 0 {
+			t.Errorf("EnvForward = %v, want empty", o.EnvForward)
+		}
+		if o.EgressProfile != string(egress.ProfilePermissive) {
+			t.Errorf("EgressProfile = %q, want %q", o.EgressProfile, egress.ProfilePermissive)
+		}
+		if o.MCP != nil {
+			t.Errorf("MCP = %+v, want nil (off by default)", o.MCP)
+		}
+		if o.Credentials != nil {
+			t.Errorf("Credentials = %+v, want nil", o.Credentials)
+		}
+		if len(o.Settings) != 0 {
+			t.Errorf("Settings = %v, want empty", o.Settings)
+		}
+		if o.CPUs != 0 || o.Memory != 0 || o.TmpSize != 0 {
+			t.Errorf("resources set without flags: cpus=%d mem=%s tmp=%s", o.CPUs, o.Memory, o.TmpSize)
+		}
+	})
+
+	t.Run("env forwarding from flags", func(t *testing.T) {
+		t.Parallel()
+		f := baseFlags
+		f.envForward = []string{"OPENAI_API_KEY", "MY_*"}
+		o, err := buildRunImageOverride(image, cmd, f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(o.EnvForward) != 2 || o.EnvForward[0] != "OPENAI_API_KEY" || o.EnvForward[1] != "MY_*" {
+			t.Errorf("EnvForward = %v, want [OPENAI_API_KEY MY_*]", o.EnvForward)
+		}
+	})
+
+	t.Run("mcp forces mode env", func(t *testing.T) {
+		t.Parallel()
+		f := baseFlags
+		f.mcp = true
+		o, err := buildRunImageOverride(image, cmd, f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.MCP == nil {
+			t.Fatalf("MCP nil, want env mode")
+		}
+		if o.MCP.Mode != domainconfig.MCPModeEnv {
+			t.Errorf("MCP.Mode = %q, want %q", o.MCP.Mode, domainconfig.MCPModeEnv)
+		}
+		if o.MCP.Authz != nil {
+			t.Errorf("MCP.Authz = %+v, want nil when no profile flag", o.MCP.Authz)
+		}
+	})
+
+	t.Run("mcp with explicit authz profile", func(t *testing.T) {
+		t.Parallel()
+		f := baseFlags
+		f.mcp = true
+		f.mcpAuthzProfile = domainconfig.MCPAuthzProfileObserve
+		o, err := buildRunImageOverride(image, cmd, f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.MCP == nil || o.MCP.Authz == nil {
+			t.Fatalf("MCP/Authz nil, want observe")
+		}
+		if o.MCP.Authz.Profile != domainconfig.MCPAuthzProfileObserve {
+			t.Errorf("MCP.Authz.Profile = %q, want %q", o.MCP.Authz.Profile, domainconfig.MCPAuthzProfileObserve)
+		}
+	})
+
+	t.Run("egress profile override", func(t *testing.T) {
+		t.Parallel()
+		f := baseFlags
+		f.egressProfile = "standard"
+		o, err := buildRunImageOverride(image, cmd, f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.EgressProfile != "standard" {
+			t.Errorf("EgressProfile = %q, want standard", o.EgressProfile)
+		}
+	})
+
+	t.Run("resources from flags", func(t *testing.T) {
+		t.Parallel()
+		f := baseFlags
+		f.cpus = 4
+		f.memory = "4g"
+		f.tmpSize = "512m"
+		o, err := buildRunImageOverride(image, cmd, f)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.CPUs != 4 {
+			t.Errorf("CPUs = %d, want 4", o.CPUs)
+		}
+		// 4g -> 4096 MiB
+		if got := o.Memory.MiB(); got != 4096 {
+			t.Errorf("Memory MiB = %d, want 4096", got)
+		}
+		if got := o.TmpSize.MiB(); got != 512 {
+			t.Errorf("TmpSize MiB = %d, want 512", got)
+		}
+	})
+
+	t.Run("empty image rejected", func(t *testing.T) {
+		t.Parallel()
+		if _, err := buildRunImageOverride("", cmd, baseFlags); err == nil {
+			t.Error("expected error for empty image, got nil")
+		}
+	})
+
+	t.Run("empty command rejected", func(t *testing.T) {
+		t.Parallel()
+		if _, err := buildRunImageOverride(image, nil, baseFlags); err == nil {
+			t.Error("expected error for empty command, got nil")
+		}
+	})
+
+	t.Run("command is copied not aliased", func(t *testing.T) {
+		t.Parallel()
+		src := []string{"aider", "--foo"}
+		o, err := buildRunImageOverride(image, src, baseFlags)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		src[0] = "mutated"
+		if o.Command[0] != "aider" {
+			t.Errorf("Command mutated by caller: %v", o.Command)
+		}
+	})
+}
+
+func TestBuildRunImageOverride_ValidateCustomAgent(t *testing.T) {
+	t.Parallel()
+
+	image := "ghcr.io/acme/tool:latest"
+	cmd := []string{"aider"}
+
+	t.Run("well-formed passes validation", func(t *testing.T) {
+		t.Parallel()
+		o, err := buildRunImageOverride(image, cmd, runImageFlags{egressProfile: "permissive"})
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		if err := domainconfig.ValidateCustomAgent("tool", o, imageRefValidator); err != nil {
+			t.Fatalf("ValidateCustomAgent: %v", err)
+		}
+	})
+
+	t.Run("empty command fails validation", func(t *testing.T) {
+		t.Parallel()
+		o := domainconfig.AgentOverride{
+			Image:         image,
+			EgressProfile: "permissive",
+		}
+		if err := domainconfig.ValidateCustomAgent("tool", o, imageRefValidator); err == nil {
+			t.Error("expected validation error for empty command, got nil")
+		}
+	})
+
+	t.Run("invalid image ref fails validation", func(t *testing.T) {
+		t.Parallel()
+		o := domainconfig.AgentOverride{
+			Image:         "::::bad ref::::",
+			Command:       cmd,
+			EgressProfile: "permissive",
+		}
+		if err := domainconfig.ValidateCustomAgent("tool", o, imageRefValidator); err == nil {
+			t.Error("expected validation error for bad image ref, got nil")
+		}
+	})
+
+	t.Run("mcp env mode with permissive egress passes without hosts", func(t *testing.T) {
+		t.Parallel()
+		f := runImageFlags{egressProfile: "standard", mcp: true}
+		o, err := buildRunImageOverride(image, cmd, f)
+		if err != nil {
+			t.Fatalf("build: %v", err)
+		}
+		// standard + mcp.mode=env is legitimate without egress_hosts (the
+		// ValidateCustomAgent exception mirrors Prepare's gateway fallback).
+		if err := domainconfig.ValidateCustomAgent("tool", o, imageRefValidator); err != nil {
+			t.Fatalf("ValidateCustomAgent with mcp env: %v", err)
+		}
+	})
+}
+
+func TestRunImageCmd_ArgParsing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("image and command split at dash", func(t *testing.T) {
+		t.Parallel()
+		cmd := runImageCmd()
+		// Override RunE to capture the parsed arg shape without invoking
+		// runRunImage (which performs I/O). The dash/command extraction logic
+		// under test is the same ArgsLenAtDash path the real RunE uses.
+		var gotImage string
+		var gotCommand []string
+		var gotDash int
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			gotDash = c.ArgsLenAtDash()
+			gotImage = args[0]
+			if gotDash >= 0 {
+				gotCommand = args[gotDash:]
+			}
+			return nil
+		}
+		cmd.SetArgs([]string{"ghcr.io/x/y:latest", "--", "aider", "--foo"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if gotImage != "ghcr.io/x/y:latest" {
+			t.Errorf("image = %q, want ghcr.io/x/y:latest", gotImage)
+		}
+		if len(gotCommand) != 2 || gotCommand[0] != "aider" || gotCommand[1] != "--foo" {
+			t.Errorf("command = %v, want [aider --foo]", gotCommand)
+		}
+		if gotDash != 1 {
+			t.Errorf("dash = %d, want 1", gotDash)
+		}
+	})
+
+	t.Run("missing dash errors before any IO", func(t *testing.T) {
+		t.Parallel()
+		cmd := runImageCmd()
+		// Keep RunE real; the dash check returns before runRunImage (no I/O).
+		cmd.SetArgs([]string{"ghcr.io/x/y:latest", "aider"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for missing --, got nil")
+		}
+		if !strings.Contains(err.Error(), "requires a command after") {
+			t.Errorf("error = %q, want substring %q", err.Error(), "requires a command after")
+		}
+	})
+
+	t.Run("empty command after dash errors before any IO", func(t *testing.T) {
+		t.Parallel()
+		cmd := runImageCmd()
+		cmd.SetArgs([]string{"ghcr.io/x/y:latest", "--"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for empty command, got nil")
+		}
+		if !strings.Contains(err.Error(), "non-empty command") {
+			t.Errorf("error = %q, want substring %q", err.Error(), "non-empty command")
+		}
+	})
+
+	t.Run("no args rejected by MinimumNArgs", func(t *testing.T) {
+		t.Parallel()
+		cmd := runImageCmd()
+		cmd.SetArgs([]string{})
+		if err := cmd.Execute(); err == nil {
+			t.Error("expected error for no args, got nil")
+		}
+	})
+}
+
+func TestRunImageCmd_FlagsRegistered(t *testing.T) {
+	t.Parallel()
+	cmd := runImageCmd()
+	for _, name := range []string{
+		"name", "env", "env-forward", "memory", "cpus", "tmp-size",
+		"mcp", "mcp-authz-profile", "mcp-group", "mcp-port", "mcp-config",
+		"mcp-session-ttl", "egress-profile", "allow-host", "workspace",
+		"workspace-mode", "review", "exclude", "yes", "ssh-port", "port",
+		"config", "debug", "log-file", "no-firmware-download",
+		"no-image-cache", "pull", "trace", "timings", "git-token",
+		"git-ssh-agent", "seed-credentials",
+	} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("flag --%s not registered", name)
+		}
+	}
+	// Egress default is permissive for run-image (opposite of root cmd).
+	if got := cmd.Flags().Lookup("egress-profile").DefValue; got != "permissive" {
+		t.Errorf("egress-profile default = %q, want permissive", got)
+	}
+	// Git token / SSH agent are opt-in (default false) for run-image — the
+	// inverse of the root command's --no-git-token / --no-git-ssh-agent.
+	if got := cmd.Flags().Lookup("git-token").DefValue; got != "false" {
+		t.Errorf("git-token default = %q, want false", got)
+	}
+	if got := cmd.Flags().Lookup("git-ssh-agent").DefValue; got != "false" {
+		t.Errorf("git-ssh-agent default = %q, want false", got)
+	}
+}
+
+func TestRunImageCmd_NameCollisionGuard(t *testing.T) {
+	t.Parallel()
+	// The collision guard (checkAgentNameCollision) rejects a run-image agent
+	// name that collides with ANY already-registered agent — built-in OR a
+	// config-declared custom agent — so a data-only entry can neither shadow a
+	// built-in's plugin nor silently overwrite a custom agent. The message
+	// distinguishes an explicit --name from a derived name.
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	registry := infraagent.NewRegistry(clients.Builtins(logger)...)
+
+	t.Run("explicit --name colliding with a built-in is rejected", func(t *testing.T) {
+		t.Parallel()
+		err := checkAgentNameCollision(registry, "claude-code", true)
+		if err == nil {
+			t.Fatal("expected collision error for built-in name, got nil")
+		}
+		if !strings.Contains(err.Error(), "--name \"claude-code\" is already in use") {
+			t.Errorf("error = %q, want --name %q is already in use", err.Error(), "claude-code")
+		}
+	})
+
+	t.Run("derived name colliding with a built-in is rejected with derived message", func(t *testing.T) {
+		t.Parallel()
+		err := checkAgentNameCollision(registry, "codex", false)
+		if err == nil {
+			t.Fatal("expected collision error, got nil")
+		}
+		if !strings.Contains(err.Error(), "derived agent name \"codex\" collides") {
+			t.Errorf("error = %q, want derived-agent-name message", err.Error())
+		}
+	})
+
+	t.Run("explicit --name colliding with a config custom agent is rejected", func(t *testing.T) {
+		t.Parallel()
+		// Use a private registry so the Add below doesn't race with the
+		// parallel built-in subtests that read the shared outer registry.
+		customReg := infraagent.NewRegistry(clients.Builtins(logger)...)
+		// Register a config-declared custom agent (data-only, nil Plugin) the
+		// way registerCustomAgents would. A run-image --name colliding with it
+		// must be rejected — previously it silently overwrote the custom agent.
+		customAg, err := domainconfig.AgentFromOverride("my-custom",
+			domainconfig.AgentOverride{
+				Image:         "ghcr.io/acme/my-custom:latest",
+				Command:       []string{"run"},
+				EgressProfile: "permissive",
+			}, domainconfig.DefaultsConfig{})
+		if err != nil {
+			t.Fatalf("AgentFromOverride: %v", err)
+		}
+		if err := customReg.Add(customAg); err != nil {
+			t.Fatalf("registry.Add: %v", err)
+		}
+		err = checkAgentNameCollision(customReg, "my-custom", true)
+		if err == nil {
+			t.Fatal("expected collision error for custom agent name, got nil")
+		}
+		if !strings.Contains(err.Error(), "--name \"my-custom\" is already in use") {
+			t.Errorf("error = %q, want --name in use", err.Error())
+		}
+	})
+
+	t.Run("non-colliding name passes", func(t *testing.T) {
+		t.Parallel()
+		// Fresh registry to avoid sharing the mutated map; a free name passes.
+		freeReg := infraagent.NewRegistry(clients.Builtins(logger)...)
+		if err := checkAgentNameCollision(freeReg, "aider-bbox", true); err != nil {
+			t.Errorf("unexpected collision for free name: %v", err)
+		}
+	})
+}
+
+func TestRunImageCmd_RunE_PreIOErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("seed-credentials rejected at parse time as incompatible", func(t *testing.T) {
+		t.Parallel()
+		cmd := runImageCmd()
+		cmd.SetArgs([]string{"ghcr.io/x/y:latest", "--seed-credentials", "--", "run"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for --seed-credentials, got nil")
+		}
+		if !strings.Contains(err.Error(), "--seed-credentials is incompatible with run-image") {
+			t.Errorf("error = %q, want substring about incompatibility", err.Error())
+		}
+	})
+
+	t.Run("invalid image ref augmented with lowercase hint", func(t *testing.T) {
+		t.Parallel()
+		cmd := runImageCmd()
+		// Uppercase repo path is rejected by name.ParseReference; the augmented
+		// error points the operator at lowercase + the docs.
+		cmd.SetArgs([]string{"ghcr.io/Acme/Tool:latest", "--", "run"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for uppercase image ref, got nil")
+		}
+		if !strings.Contains(err.Error(), "OCI references must be lowercase") {
+			t.Errorf("error = %q, want lowercase hint", err.Error())
+		}
+		if !strings.Contains(err.Error(), "docs/run-image.md") {
+			t.Errorf("error = %q, want docs/run-image.md pointer", err.Error())
+		}
+	})
+
+	t.Run("invalid explicit --name rejected before any IO", func(t *testing.T) {
+		t.Parallel()
+		cmd := runImageCmd()
+		// Valid image, invalid --name (spaces / punctuation). ValidateName
+		// fires before openLogFile / buildResolvedRegistry, so no I/O.
+		cmd.SetArgs([]string{"ghcr.io/x/y:latest", "--name", "Bad Name!", "--", "run"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for invalid --name, got nil")
+		}
+		// Explicit --name branch: the message must NOT blame a derived name.
+		if strings.Contains(err.Error(), "derived from image") {
+			t.Errorf("error = %q, must not mention 'derived from image' for explicit --name", err.Error())
+		}
+		if !strings.Contains(err.Error(), "invalid agent name") {
+			t.Errorf("error = %q, want 'invalid agent name'", err.Error())
+		}
+	})
+
+	t.Run("missing dash errors before any IO", func(t *testing.T) {
+		t.Parallel()
+		cmd := runImageCmd()
+		cmd.SetArgs([]string{"ghcr.io/x/y:latest", "aider"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for missing --, got nil")
+		}
+		if !strings.Contains(err.Error(), "requires a command after") {
+			t.Errorf("error = %q, want substring 'requires a command after'", err.Error())
+		}
+	})
+
+	t.Run("empty command after dash errors before any IO", func(t *testing.T) {
+		t.Parallel()
+		cmd := runImageCmd()
+		cmd.SetArgs([]string{"ghcr.io/x/y:latest", "--"})
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("expected error for empty command, got nil")
+		}
+		if !strings.Contains(err.Error(), "non-empty command") {
+			t.Errorf("error = %q, want substring 'non-empty command'", err.Error())
+		}
+	})
+}
+
+func TestRunImageCmd_NameWinsOverDerivation(t *testing.T) {
+	t.Parallel()
+	// --name set (non-empty) is used verbatim; deriveAgentName is not called
+	// for the name. We exercise the RunE with a valid --name and confirm it
+	// reaches name validation (passes) and proceeds — the only observable
+	// pre-IO signal is that it does NOT return an "invalid agent name ...
+	// derived from image" error. With a non-colliding, valid --name and a
+	// valid image, runRunImage proceeds past name validation into I/O
+	// (openLogFile in a real config dir); to keep this hermetic we instead
+	// assert the resolution predicate directly: --name non-empty => the
+	// name used is exactly --name, and the derived branch is skipped.
+	//
+	// This mirrors the inline resolution in runRunImage:
+	//   nameFromFlag = f.name != ""; if !nameFromFlag { agentName = derive(image) }
+	tests := []struct {
+		name  string
+		flag  string
+		image string
+		want  string
+		from  bool
+	}{
+		{name: "explicit name wins", flag: "aider-bbox", image: "ghcr.io/acme/Other:latest", want: "aider-bbox", from: true},
+		{name: "empty name derives", flag: "", image: "ghcr.io/acme/Aider-Bbox:latest", want: "aider-bbox", from: false},
+		{name: "empty name derives from dockerhub", flag: "", image: "ubuntu:24.04", want: "ubuntu", from: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agentName := tt.flag
+			nameFromFlag := agentName != ""
+			if !nameFromFlag {
+				agentName = deriveAgentName(tt.image)
+			}
+			if agentName != tt.want {
+				t.Errorf("resolved name = %q, want %q", agentName, tt.want)
+			}
+			if nameFromFlag != tt.from {
+				t.Errorf("nameFromFlag = %v, want %v", nameFromFlag, tt.from)
+			}
+		})
+	}
+}
+
+func TestRunImageCmd_EnvAliasMerge(t *testing.T) {
+	t.Parallel()
+	// --env and --env-forward are aliases that both append to the same
+	// forwarding list. Set both via cobra flags and confirm both land in the
+	// merged envForward passed to runRunImage.
+	var gotEnv []string
+	cmd := runImageCmd()
+	// Capture envForward after flag parsing by swapping in a RunE that records
+	// the merged slice and returns before any I/O. The merge logic under test
+	// (append(envFwd, envFwdAlt...)) runs in the real RunE before runRunImage.
+	cmd.RunE = func(c *cobra.Command, _ []string) error {
+		envFwd, _ := c.Flags().GetStringSlice("env")
+		envFwdAlt, _ := c.Flags().GetStringSlice("env-forward")
+		gotEnv = append(append([]string{}, envFwd...), envFwdAlt...)
+		return nil
+	}
+	cmd.SetArgs([]string{
+		"ghcr.io/x/y:latest",
+		"--env", "OPENAI_API_KEY",
+		"--env-forward", "MY_PREFIX_*",
+		"--", "run",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(gotEnv) != 2 || gotEnv[0] != "OPENAI_API_KEY" || gotEnv[1] != "MY_PREFIX_*" {
+		t.Errorf("merged envForward = %v, want [OPENAI_API_KEY MY_PREFIX_*]", gotEnv)
+	}
+}
+
+func TestValidateMCPFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		profile string
+		ttl     time.Duration
+		wantErr bool
+		substr  string
+	}{
+		{name: "empty profile zero ttl ok", profile: "", ttl: 0, wantErr: false},
+		{name: "valid profile ok", profile: "observe", ttl: 0, wantErr: false},
+		{name: "safe-tools ok", profile: "safe-tools", ttl: 0, wantErr: false},
+		{name: "custom ok", profile: "custom", ttl: 0, wantErr: false},
+		{name: "invalid profile rejected", profile: "bogus", ttl: 0, wantErr: true, substr: "invalid --mcp-authz-profile"},
+		{name: "positive ttl ok", profile: "", ttl: 30 * time.Minute, wantErr: false},
+		{name: "zero ttl ok", profile: "", ttl: 0, wantErr: false},
+		{name: "negative ttl rejected", profile: "", ttl: -1 * time.Minute, wantErr: true, substr: "must be non-negative"},
+		{name: "invalid profile and negative ttl reports profile first", profile: "bogus", ttl: -1, wantErr: true, substr: "invalid --mcp-authz-profile"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateMCPFlags(tt.profile, tt.ttl)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.substr) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tt.substr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunImage_DetachAgentsMap(t *testing.T) {
+	t.Parallel()
+	// runRunImage detaches cfg.Agents before injecting the run-image override
+	// so the ephemeral entry does not leak back into the global config object
+	// (MergeConfigs shallow-copies; when local has no agents, merged.Agents
+	// aliases global.Agents). We can't call runRunImage hermetically (it does
+	// VM I/O), so we exercise the detach step inline: it is a plain map copy.
+	global := &domainconfig.Config{
+		Agents: map[string]domainconfig.AgentOverride{
+			"existing": {Image: "ghcr.io/acme/existing:latest", Command: []string{"run"}},
+		},
+	}
+	// Simulate MergeConfigs(local=nil) returning global (aliased Agents).
+	merged := global
+	originalAgents := merged.Agents
+
+	// Detach (the exact step runRunImage performs).
+	detached := make(map[string]domainconfig.AgentOverride, len(merged.Agents)+1)
+	for k, v := range merged.Agents {
+		detached[k] = v
+	}
+	merged.Agents = detached
+	merged.Agents["run-image-ephemeral"] = domainconfig.AgentOverride{
+		Image: "ghcr.io/x/y:latest", Command: []string{"run"},
+	}
+
+	// The override landed on the merged config's detached map.
+	if _, ok := merged.Agents["run-image-ephemeral"]; !ok {
+		t.Error("override not present on merged.Agents")
+	}
+	// The original (global) Agents map is untouched — no aliasing leak.
+	if _, ok := originalAgents["run-image-ephemeral"]; ok {
+		t.Error("override leaked into the original global Agents map (aliasing bug)")
+	}
+	if len(originalAgents) != 1 {
+		t.Errorf("original global Agents map mutated: %v", originalAgents)
+	}
+	if _, ok := originalAgents["existing"]; !ok {
+		t.Errorf("original global Agents lost 'existing': %v", originalAgents)
+	}
+}

--- a/docs/run-image.md
+++ b/docs/run-image.md
@@ -1,0 +1,123 @@
+<!-- SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# `bbox run-image` — ephemeral one-shot
+
+`bbox run-image IMAGE [flags] -- CMD [args...]` boots an arbitrary OCI image in
+a hardware-isolated microVM, runs `CMD` inside it, and persists nothing. It
+builds an in-memory agent from the flags (no config-file mutation, no registry
+persistence) and runs it through the normal sandbox path — the same path a
+built-in or custom agent takes.
+
+The image is the first positional argument. The command to run inside the VM
+follows a literal `--` and is **required**.
+
+```bash
+# Boot an arbitrary image and run a command
+bbox run-image ghcr.io/jbarslox/aider-bbox:latest -- aider
+
+# Restrict egress and forward only one env var
+bbox run-image ubuntu:24.04 \
+  --env OPENAI_API_KEY \
+  --egress-profile standard \
+  --allow-host api.openai.com:443 \
+  -- python -m http.server
+
+# Enable the MCP proxy (the agent discovers it via BBOX_MCP_URL)
+bbox run-image ghcr.io/me/my-tool:latest --mcp -- my-tool
+```
+
+## Ephemeral defaults
+
+`run-image` is safer-by-default than a custom agent declared in config:
+
+| Feature | Default | Opt in / tighten |
+|---|---|---|
+| Credential persistence | **OFF** | (no opt-in — by design ephemeral) |
+| Host settings import | **OFF** | (no opt-in — ephemeral) |
+| Env forwarding | **EMPTY** (forward nothing) | `--env` (repeatable) |
+| Git token forwarding | **OFF** | `--git-token` |
+| SSH agent forwarding | **OFF** | `--git-ssh-agent` |
+| MCP proxy | **OFF** | `--mcp` |
+| Egress | **permissive** (disclosed on stderr) | `--egress-profile standard --allow-host ...` |
+| Snapshot isolation | **ON** (same as `bbox`) | `--workspace-mode=direct` |
+| Interactive review | OFF | `--review` |
+
+Egress defaults to `permissive` so the bare `bbox run-image IMG -- cmd` example
+boots without first declaring egress hosts. A one-line disclosure is printed to
+stderr each run. Tighten with `--egress-profile standard` (or `locked`) plus
+`--allow-host`.
+
+Unlike the root command (which forwards `GITHUB_TOKEN`/`GH_TOKEN` and the SSH
+agent by default and lets `--no-git-token`/`--no-git-ssh-agent` disable them),
+`run-image` forwards **neither** into an arbitrary image by default. Opt in with
+`--git-token` / `--git-ssh-agent`; a stderr line is printed when either is set.
+This is the safer posture for an ephemeral run against an untrusted image.
+
+`--seed-credentials` is rejected: credential persistence is always OFF for an
+ephemeral run, so seeding would be a silent no-op.
+
+## MCP
+
+`--mcp` enables the MCP tool proxy and forces `mcp.mode=env`: the proxy is
+exposed to the agent only via the universal `BBOX_MCP_URL` environment variable.
+There is no config-file injector for an arbitrary image. The default
+authorization profile for a run-image agent with MCP enabled is `safe-tools`
+(the custom-agent default); override with `--mcp-authz-profile`.
+
+## Name derivation
+
+When `--name` is unset, the agent name (used for the VM name, logs, and
+`BBOX_AGENT_NAME`) is derived from the image reference: the repository basename
+(last path segment, after stripping any tag/digest), lower-cased, with runs of
+non-`[a-z0-9-]` replaced by `-`. Example: `ghcr.io/me/Aider-Bbox:latest` →
+`aider-bbox`. Pass `--name` to override.
+
+`--name` may not collide with a built-in agent **or a config-declared custom
+agent** (a data-only run-image entry would shadow the built-in's plugin or
+silently overwrite the custom agent); choose a distinct name. When the name is
+derived (no `--name`) and still collides, pass `--name` to override.
+
+## Minimum image contract
+
+An arbitrary image used with `run-image` must provide:
+
+- A Linux rootfs (the image is extracted as the VM rootfs). `x86_64` or `arm64`
+  matching the host.
+- The agent command (the `-- CMD`) resolvable on `PATH` inside the image, or an
+  absolute path.
+- A POSIX shell at `/bin/sh` (used by `bbox-init` for command invocation).
+- A non-root sandbox user expected at UID 1000 with home `/home/sandbox`.
+  `bbox-init` provisions this; the image should not override it destructively.
+  If the image lacks the user, `bbox-init` creates it.
+- A standard CA bundle at `/etc/ssl/certs` for outbound TLS.
+
+`bbox-init` is **not** in the image — it is embedded by the VM runtime and runs
+as PID 1. The image only provides the userspace/agent tooling.
+
+## Flags
+
+`run-image` accepts a subset of the root command's flags. Notable differences:
+
+- `--env` / `--env-forward` — both are aliases; forward a host env var (exact
+  name or glob like `PREFIX_*`), repeatable. Empty by default.
+- `--mcp` — enables the MCP proxy (off by default; the opposite of the root
+  command, where MCP is on by default and `--no-mcp` disables it).
+- `--egress-profile` — defaults to `permissive`.
+- `--git-token` / `--git-ssh-agent` — opt-in (default OFF) forwarding of the git
+  token / SSH agent; the inverse of the root command's `--no-git-token` /
+  `--no-git-ssh-agent`.
+- `--seed-credentials` — registered but rejected: incompatible with ephemeral
+  runs (credential persistence is always OFF).
+- `--image` is **not** exposed (the image is the positional arg).
+- `--exec` is **not** exposed (the command is the `--` args).
+
+All resource (`--cpus`, `--memory`, `--tmp-size`), workspace (`--workspace`,
+`--workspace-mode`, `--review`, `--exclude`, `--yes`), networking
+(`--ssh-port`, `--port`, `--allow-host`), MCP, runtime (`--no-firmware-download`,
+`--no-image-cache`, `--pull`), and observability (`--debug`, `--log-file`,
+`--trace`, `--timings`) flags work as on the root command.
+
+Global config (`~/.config/broodbox/config.yaml`) is still loaded for defaults
+(egress hosts, MCP defaults, resource ceilings); `--config` selects an
+alternate path.


### PR DESCRIPTION
## Summary

Implements #205 — `bbox run-image IMAGE [flags] -- CMD`, an ephemeral one-shot that boots an arbitrary OCI image in a sandbox VM, runs the command, forwards only explicitly-requested env, and persists nothing. No config-file mutation, no registry persistence.

```bash
bbox run-image ghcr.io/me/aider-bbox:latest -- aider --model gpt-5

bbox run-image ghcr.io/me/aider-bbox:latest \
  --name aider --env OPENAI_API_KEY --env 'AIDER_*' \
  --memory 4g --cpus 4 --mcp --mcp-authz-profile safe-tools \
  --egress-profile standard --allow-host api.openai.com:443 -- aider
```

Builds an in-memory `agent.Agent` from flags via the existing `config.AgentFromOverride` path (#200) and runs it through the normal `SandboxRunner`.

## Ephemeral defaults (safer-than-custom)
| Feature | Default | Opt-in |
|---|---|---|
| Credential persistence | OFF | (ephemeral by design) |
| Settings import | OFF | (ephemeral by design) |
| Env forwarding | EMPTY | `--env` (repeatable; `--env-forward` alias) |
| MCP proxy | OFF | `--mcp` (forces `mcp.mode=env`; inherits `safe-tools` authz default) |
| Git token forwarding | OFF | `--git-token` |
| SSH agent forwarding | OFF | `--git-ssh-agent` |
| Egress | `permissive` (with stderr disclosure) | `--egress-profile standard --allow-host ...` |

Snapshot isolation, review, egress/MCP tighten-only semantics all still apply. Universal `BBOX_*` env vars are injected as for any agent.

## How it works
- New cobra subcommand `run-image` (cmd/bbox/run_image.go). The first positional is the image; everything after `--` is the command.
- Reuses `run()` by extracting a shared `runSandbox(...)` tail (cmd/bbox/main.go); `run()` keeps its front-end, `runRunImage()` builds the in-memory agent then calls the same tail.
- The ephemeral agent is registered data-only (nil Plugin) via `registry.Add` — same seam `registerCustomAgents` uses — so `isCustomAgent`/`applyCustomAgentAuthzDefault` apply the `safe-tools` MCP authz default. Nothing is written to disk.
- Name derives from the image repo basename (sanitized) when `--name` is unset; validated via `agent.ValidateName`.
- Pure helpers `buildRunImageOverride` and `deriveAgentName` are table-tested; `validateMCPFlags` extracted to de-duplicate front-end validation.

## Minimum image contract
Documented in `docs/run-image.md`: the image provides the Linux rootfs; the agent command must be on `PATH` inside the image; `/bin/sh` and a CA bundle at `/etc/ssl/certs` are expected; sandbox user UID 1000 / `/home/sandbox`. `bbox-init` is embedded by the VM runtime (PID 1), not the image.

## Verification
- `task fmt` — clean
- `task lint` — 0 issues
- `task test` (race) — all green, incl. new `cmd/bbox` tests
- New tests: `deriveAgentName`, `buildRunImageOverride` (defaults/env/mcp/authz/egress/resources/copy-semantics), `ValidateCustomAgent` accept/reject, cobra arg parsing (`IMG -- CMD`, missing `--`, empty command), RunE pre-IO errors (`--seed-credentials` rejection, invalid image ref with lowercase hint, invalid `--name`), name-collision guard (built-in + custom + derived), `--name` wins-over-derivation, `--env`/`--env-forward` alias merge, `validateMCPFlags`, and the `cfg.Agents` map-detach (no aliasing into global config).

## Review-panel driven changes
A spec + standards + domain (security/arch/UX/DevEx/duplication/QA) panel reviewed the diff; this commit applies the cross-confirmed findings: git-token/SSH-agent off-by-default (contradicts the issue's "forwards only explicitly requested env"), `--seed-credentials` rejected as incompatible, name-collision guard covers custom agents (not just built-ins), dead `name` param dropped, derived agent name surfaced on stderr, MCP validation de-duplicated, `cfg.Agents` map-aliasing fixed, image-contract discoverable from `--help`, image-ref error hints lowercase refs.

## Notes / out of scope
- `runSandbox` still hard-codes `infravm.NewMicroVMRunner` (no VMRunner injection). A full Prepare-boundary E2E test isn't reachable without that refactor; RunE-level tests stop at the pre-`runSandbox` boundary (guard, flag parsing, pure helpers). Left for a follow-up.
- The OCI-manifest minimum-image-contract verification (Phase 5 follow-up) is documented but not enforced here.

Closes #205.